### PR TITLE
Pipeline Info

### DIFF
--- a/src/saturn_engine/core/__init__.py
+++ b/src/saturn_engine/core/__init__.py
@@ -1,3 +1,4 @@
 from .message import Message
+from .resource import Resource
 
-__all__ = ["Message"]
+__all__ = ["Message", "Resource"]

--- a/src/saturn_engine/core/resource.py
+++ b/src/saturn_engine/core/resource.py
@@ -1,0 +1,15 @@
+import dataclasses
+from typing import Any
+from typing import ClassVar
+from typing import Optional
+
+
+@dataclasses.dataclass(eq=False)
+class Resource:
+    data: Any
+
+    typename: ClassVar[Optional[str]] = None
+
+    @classmethod
+    def _typename(cls) -> str:
+        return cls.typename or cls.__name__

--- a/src/saturn_engine/utils/inspect.py
+++ b/src/saturn_engine/utils/inspect.py
@@ -1,0 +1,109 @@
+import inspect
+import sys
+from typing import Callable
+from typing import Type
+
+
+def eval_annotations(func: Callable, signature: inspect.Signature) -> inspect.Signature:
+    is_dirty = False
+    evaluated_parameters: list[inspect.Parameter] = []
+    for parameter in signature.parameters.values():
+        if isinstance(parameter.annotation, str):
+            is_dirty = True
+            parameter = parameter.replace(
+                annotation=eval_annotation(func, parameter.annotation)
+            )
+        evaluated_parameters.append(parameter)
+
+    if is_dirty:
+        signature = signature.replace(parameters=evaluated_parameters)
+
+    if isinstance(signature.return_annotation, str):
+        signature = signature.replace(
+            return_annotation=eval_annotation(func, signature.return_annotation)
+        )
+
+    return signature
+
+
+# Taken from cpython 3.10 inspect.get_annotations
+def eval_annotation(func: Callable, annotation: str) -> Type:
+    unwrap = func
+    while True:
+        if hasattr(unwrap, "__wrapped__"):
+            unwrap = unwrap.__wrapped__  # type: ignore[attr-defined]
+            continue
+        break
+    obj_globals = getattr(unwrap, "__globals__", None)
+    # Scary eval! This is safe because only used on function object annotations.
+    # If someone is able to build arbitrary function object, then it's able to
+    # do much more than eval.
+    return eval(annotation, obj_globals, None)  # noqa: S307
+
+
+# Taken from CPython pickle.py
+def get_import_names(obj: Callable) -> tuple[str, str]:
+    name = getattr(obj, "__qualname__", None)
+    if name is None:
+        name = obj.__name__
+
+    module_name = whichmodule(obj, name)
+    try:
+        __import__(module_name, level=0)
+        module = sys.modules[module_name]
+        obj2, parent = getattribute(module, name)
+    except (ImportError, KeyError, AttributeError):
+        raise ValueError(
+            "Can't get %r info: it's not found as %s.%s" % (obj, module_name, name)
+        ) from None
+    else:
+        if obj2 is not obj:
+            raise ValueError(
+                "Can't get %r info: it's not the same object as %s.%s"
+                % (obj, module_name, name)
+            )
+
+    return module_name, name
+
+
+def getattribute(obj: object, name: str) -> tuple[object, object]:
+    for subpath in name.split("."):
+        if subpath == "<locals>":
+            raise AttributeError(
+                "Can't get local attribute {!r} on {!r}".format(name, obj)
+            )
+        try:
+            parent = obj
+            obj = getattr(obj, subpath)
+        except AttributeError:
+            raise AttributeError(
+                "Can't get attribute {!r} on {!r}".format(name, obj)
+            ) from None
+    return obj, parent
+
+
+def whichmodule(obj: object, name: str) -> str:
+    """Find the module an object belong to."""
+    module_name = getattr(obj, "__module__", None)
+    if module_name is not None:
+        return module_name
+    # Protect the iteration by using a list copy of sys.modules against dynamic
+    # modules that trigger imports of other modules upon calls to getattr.
+    for module_name, module in sys.modules.copy().items():
+        if (
+            module_name == "__main__"
+            or module_name == "__mp_main__"  # bpo-42406
+            or module is None
+        ):
+            continue
+        try:
+            if getattribute(module, name)[0] is obj:
+                return module_name
+        except AttributeError:
+            pass
+    return "__main__"
+
+
+def import_name(module: str, name: str) -> object:
+    __import__(module, level=0)
+    return getattribute(sys.modules[module], name)[0]

--- a/src/saturn_engine/worker/pipeline_info.py
+++ b/src/saturn_engine/worker/pipeline_info.py
@@ -1,0 +1,36 @@
+import dataclasses
+import inspect
+from typing import Callable
+from typing import cast
+
+from saturn_engine.core import Resource
+from saturn_engine.utils import inspect as extra_inspect
+
+
+@dataclasses.dataclass
+class PipelineInfo:
+    module: str
+    name: str
+    resources: dict[str, str]
+
+    def into_pipeline(self) -> Callable:
+        return cast(Callable, extra_inspect.import_name(self.module, self.name))
+
+    @classmethod
+    def from_pipeline(cls, pipeline: Callable) -> "PipelineInfo":
+        module, name = extra_inspect.get_import_names(pipeline)
+        try:
+            signature = inspect.signature(pipeline)
+            signature = extra_inspect.eval_annotations(pipeline, signature)
+        except Exception as e:
+            raise ValueError("Can't parse signature") from e
+        resources = cls.get_resources(signature)
+        return cls(module=module, name=name, resources=resources)
+
+    @staticmethod
+    def get_resources(signature: inspect.Signature) -> dict[str, str]:
+        resources = {}
+        for parameter in signature.parameters.values():
+            if issubclass(parameter.annotation, Resource):
+                resources[parameter.name] = parameter.annotation._typename()
+        return resources

--- a/src/saturn_engine/worker/resource.py
+++ b/src/saturn_engine/worker/resource.py
@@ -1,7 +1,0 @@
-import dataclasses
-from typing import Any
-
-
-@dataclasses.dataclass(eq=False)
-class Resource:
-    data: Any

--- a/src/saturn_engine/worker/services/resources_manager.py
+++ b/src/saturn_engine/worker/services/resources_manager.py
@@ -3,7 +3,7 @@ import contextlib
 from collections import defaultdict
 from typing import Optional
 
-from saturn_engine.worker.resource import Resource
+from saturn_engine.core import Resource
 
 
 class ResourceUnavailable(Exception):

--- a/tests/worker/test_pipeline_info.py
+++ b/tests/worker/test_pipeline_info.py
@@ -1,0 +1,107 @@
+from functools import wraps
+from typing import Callable
+
+import pytest
+
+from saturn_engine.core import Resource
+from saturn_engine.worker.pipeline_info import PipelineInfo
+
+
+class ResourceA(Resource):
+    typename = "resource_a"
+
+
+class ResourceB(Resource):
+    pass
+
+
+def simple_pipeline() -> None:
+    ...
+
+
+def pipeline_with_resources(a: ResourceA, b: "ResourceB") -> None:
+    ...
+
+
+class Namespace:
+    def pipeline(self) -> None:
+        ...
+
+
+def deleted_pipeline() -> None:
+    ...
+
+
+def modified_pipeline() -> None:
+    ...
+
+
+def decorator(func: Callable) -> Callable:
+    @wraps(func)
+    def wrapper() -> None:
+        ...
+
+    return wrapper
+
+
+@decorator
+def wrapped_pipeline() -> None:
+    ...
+
+
+def test_pipeline_info_name() -> None:
+    global deleted_pipeline, modified_pipeline
+
+    def local_pipeline() -> None:
+        ...
+
+    assert PipelineInfo.from_pipeline(simple_pipeline) == PipelineInfo(
+        module="tests.worker.test_pipeline_info", name="simple_pipeline", resources={}
+    )
+
+    assert PipelineInfo.from_pipeline(Namespace.pipeline) == PipelineInfo(
+        module="tests.worker.test_pipeline_info",
+        name="Namespace.pipeline",
+        resources={},
+    )
+
+    assert PipelineInfo.from_pipeline(wrapped_pipeline) == PipelineInfo(
+        module="tests.worker.test_pipeline_info", name="wrapped_pipeline", resources={}
+    )
+
+    with pytest.raises(ValueError):
+        PipelineInfo.from_pipeline(local_pipeline)
+
+    with pytest.raises(ValueError):
+        pipeline = deleted_pipeline
+        del deleted_pipeline
+        PipelineInfo.from_pipeline(pipeline)
+
+    with pytest.raises(ValueError):
+        pipeline = modified_pipeline
+        modified_pipeline = simple_pipeline
+        PipelineInfo.from_pipeline(pipeline)
+
+
+def test_pipeline_info_resources() -> None:
+    assert PipelineInfo.from_pipeline(pipeline_with_resources) == PipelineInfo(
+        module="tests.worker.test_pipeline_info",
+        name="pipeline_with_resources",
+        resources={
+            "a": "resource_a",
+            "b": "ResourceB",
+        },
+    )
+
+
+def test_pipeline_info_load() -> None:
+    assert (
+        PipelineInfo.from_pipeline(simple_pipeline).into_pipeline() is simple_pipeline
+    )
+    assert (
+        PipelineInfo.from_pipeline(Namespace.pipeline).into_pipeline()
+        is Namespace.pipeline
+    )
+    assert (
+        PipelineInfo.from_pipeline(wrapped_pipeline).into_pipeline() is wrapped_pipeline
+    )

--- a/tests/worker/test_resources_manager.py
+++ b/tests/worker/test_resources_manager.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from saturn_engine.worker.resource import Resource
+from saturn_engine.core import Resource
 from saturn_engine.worker.services.resources_manager import ResourcesManager
 from saturn_engine.worker.services.resources_manager import ResourceUnavailable
 from tests.utils import TimeForwardLoop


### PR DESCRIPTION
Add pipeline info loader and dumper.

This should reflect the data sent to the worker. Pipeline are just functions:

```
# cat.py
def download_cat(url: str, api_key:: CatApiKey) -> Response: ...
```

so the admin can create a new job with the pipeline info by using: `PipelineInfo.from_pipeline(download_cat)`.

The serializable data can then be sent to the worker:

```json
{
  "module": "cat",
  "name": "download_cat",
  "resources": {"api_key": "CatApiKey"}
}
```

And from there the worker can acquire the resource, load the pipeline function and pass the resource with the right name!


Depends on #31 