### PR TITLE
inventory: the cursor is opaque

### DIFF
--- a/src/saturn_engine/worker/inventories/__init__.py
+++ b/src/saturn_engine/worker/inventories/__init__.py
@@ -7,10 +7,10 @@ from saturn_engine.utils.options import OptionsSchema
 
 @dataclasses.dataclass
 class Item:
-    id: int
+    id: str
     data: dict[str, object]
 
 
 class Inventory(OptionsSchema):
-    async def next_batch(self, after: Optional[int] = None) -> Iterable[Item]:
+    async def next_batch(self, after: Optional[str] = None) -> Iterable[Item]:
         return []

--- a/src/saturn_engine/worker/inventories/dummy.py
+++ b/src/saturn_engine/worker/inventories/dummy.py
@@ -14,9 +14,9 @@ class DummyInventory(Inventory):
     def __init__(self, options: Options) -> None:
         self.count = options.count or 1000
 
-    async def next_batch(self, after: Optional[int] = None) -> Iterable[Item]:
-        n = after + 1 if after is not None else 0
+    async def next_batch(self, after: Optional[str] = None) -> Iterable[Item]:
+        n = int(after) + 1 if after is not None else 0
         n_end = min(n + 100, self.count)
         if n_end == n:
             return []
-        return [Item(id=i, data={"n": i}) for i in range(n, n_end)]
+        return [Item(id=str(i), data={"n": i}) for i in range(n, n_end)]

--- a/src/saturn_engine/worker/job/__init__.py
+++ b/src/saturn_engine/worker/job/__init__.py
@@ -10,10 +10,10 @@ from ..queues import Publisher
 
 
 class JobStore(OptionsSchema):
-    async def load_cursor(self) -> Optional[int]:
+    async def load_cursor(self) -> Optional[str]:
         pass
 
-    async def save_cursor(self, *, after: int) -> None:
+    async def save_cursor(self, *, after: str) -> None:
         pass
 
 
@@ -25,13 +25,11 @@ class Job:
         self.inventory = inventory
         self.publisher = publisher
         self.store = store
-        self.after: Optional[int] = None
+        self.after: Optional[str] = None
 
     async def push_batch(self, items: list[Item]) -> None:
         try:
             for item in items:
-                if self.after is not None and item.id <= self.after:
-                    self.logger.error("Unordered items: %s <= %s", item.id, self.after)
                 self.after = item.id
                 message = TopicMessage(id=str(item.id), args=item.data)
                 await self.publisher.push(message)

--- a/src/saturn_engine/worker/job/memory.py
+++ b/src/saturn_engine/worker/job/memory.py
@@ -6,10 +6,10 @@ from . import JobStore
 
 class MemoryJobStore(JobStore):
     def __init__(self, **kwargs: Any) -> None:
-        self.after: Optional[int] = None
+        self.after: Optional[str] = None
 
-    async def load_cursor(self) -> Optional[int]:
+    async def load_cursor(self) -> Optional[str]:
         return self.after
 
-    async def save_cursor(self, *, after: int) -> None:
+    async def save_cursor(self, *, after: str) -> None:
         self.after = after


### PR DESCRIPTION
I think its best if inventory cursors remain opaque strings.

They can be json objects, es search_afters, or anything as long as they can be serialized into strings to be persisted.