### PR TITLE
inventories: create BlockingInventory

### DIFF
--- a/src/saturn_engine/worker/inventories/__init__.py
+++ b/src/saturn_engine/worker/inventories/__init__.py
@@ -1,3 +1,5 @@
+import abc
+import asyncio
 import dataclasses
 from collections.abc import Iterable
 from typing import Optional
@@ -16,6 +18,19 @@ class Item:
 class Inventory(OptionsSchema):
     async def next_batch(self, after: Optional[str] = None) -> Iterable[Item]:
         return []
+
+
+class BlockingInventory(Inventory, abc.ABC):
+    async def next_batch(self, after: Optional[str] = None) -> Iterable[Item]:
+        return await asyncio.get_event_loop().run_in_executor(
+            None,
+            self.next_batch_blocking,
+            (after,),
+        )
+
+    @abc.abstractmethod
+    def next_batch_blocking(self, after: Optional[str] = None) -> Iterable[Item]:
+        raise NotImplementedError()
 
 
 from .dummy import DummyInventory

--- a/tests/worker/inventories/test_blocking_inventory.py
+++ b/tests/worker/inventories/test_blocking_inventory.py
@@ -1,0 +1,19 @@
+from typing import Iterable
+from typing import Optional
+
+import pytest
+
+from saturn_engine.worker.inventories import BlockingInventory
+from saturn_engine.worker.inventories import Item
+
+
+@pytest.mark.asyncio
+async def test_blocking_inventory() -> None:
+    class BI(BlockingInventory):
+        def next_batch_blocking(self, after: Optional[str] = None) -> Iterable[Item]:
+            # Don't really block here as we want tests to be fast.
+            # This still tests almost completely that BlockingInventory works.
+            return [Item(id="66", data=dict())]
+
+    batch = list(await BI.from_options(dict()).next_batch())
+    assert batch[0].id == "66"


### PR DESCRIPTION
I create an executor every time we call `next_batch`.

Another option is to do:
```python
@staticmethod
@cache
def get_executor() -> Executor: ...
```

And use the same executor for all calls, but then it isn't clear who should shutdown the executor.