### PR TITLE
rename Item.data -> Item.args

### DIFF
--- a/src/saturn_engine/worker/inventories/__init__.py
+++ b/src/saturn_engine/worker/inventories/__init__.py
@@ -2,6 +2,7 @@ import abc
 import asyncio
 import dataclasses
 from collections.abc import Iterable
+from typing import Any
 from typing import Optional
 
 from saturn_engine.utils.options import OptionsSchema
@@ -12,7 +13,7 @@ __all__ = ("Item", "Inventory", "BUILTINS")
 @dataclasses.dataclass
 class Item:
     id: str
-    data: dict[str, object]
+    args: dict[str, Any]
 
 
 class Inventory(OptionsSchema):

--- a/src/saturn_engine/worker/inventories/dummy.py
+++ b/src/saturn_engine/worker/inventories/dummy.py
@@ -19,4 +19,4 @@ class DummyInventory(Inventory):
         n_end = min(n + 100, self.count)
         if n_end == n:
             return []
-        return [Item(id=str(i), data={"n": i}) for i in range(n, n_end)]
+        return [Item(id=str(i), args={"n": i}) for i in range(n, n_end)]

--- a/src/saturn_engine/worker/job/__init__.py
+++ b/src/saturn_engine/worker/job/__init__.py
@@ -31,7 +31,7 @@ class Job:
         try:
             for item in items:
                 self.after = item.id
-                message = TopicMessage(id=str(item.id), args=item.data)
+                message = TopicMessage(id=str(item.id), args=item.args)
                 await self.publisher.publish(message, wait=True)
         finally:
             if self.after is not None:

--- a/tests/worker/inventories/test_blocking_inventory.py
+++ b/tests/worker/inventories/test_blocking_inventory.py
@@ -13,7 +13,7 @@ async def test_blocking_inventory() -> None:
         def next_batch_blocking(self, after: Optional[str] = None) -> Iterable[Item]:
             # Don't really block here as we want tests to be fast.
             # This still tests almost completely that BlockingInventory works.
-            return [Item(id="66", data=dict())]
+            return [Item(id="66", args=dict())]
 
     batch = list(await BI.from_options(dict()).next_batch())
     assert batch[0].id == "66"


### PR DESCRIPTION
Was there any reasons they needed to be dicts?

I am building one right now that could be an instance of an sdk object.