### PR TITLE
worker(job-store): Add an API job store that use the worker manager API.

### DIFF
--- a/src/saturn_engine/worker/job/__init__.py
+++ b/src/saturn_engine/worker/job/__init__.py
@@ -1,3 +1,4 @@
+import abc
 from typing import Optional
 
 from saturn_engine.core import TopicMessage
@@ -9,10 +10,12 @@ from ..inventories import Item
 from ..topics import Topic
 
 
-class JobStore(OptionsSchema):
+class JobStore(OptionsSchema, abc.ABC):
+    @abc.abstractmethod
     async def load_cursor(self) -> Optional[str]:
         pass
 
+    @abc.abstractmethod
     async def save_cursor(self, *, after: str) -> None:
         pass
 
@@ -38,6 +41,9 @@ class Job:
                 await self.store.save_cursor(after=self.after)
 
     async def run(self) -> None:
+        if self.after is None:
+            self.after = await self.store.load_cursor()
+
         while True:
             items = list(await self.inventory.next_batch(after=self.after))
             if not items:

--- a/src/saturn_engine/worker/job/api.py
+++ b/src/saturn_engine/worker/job/api.py
@@ -1,0 +1,50 @@
+from typing import Any
+from typing import Optional
+
+import aiohttp
+
+from saturn_engine.core.api import JobInput
+from saturn_engine.core.api import JobResponse
+from saturn_engine.utils import DelayedThrottle
+from saturn_engine.utils import urlcat
+from saturn_engine.utils.log import getLogger
+from saturn_engine.utils.options import asdict
+from saturn_engine.utils.options import fromdict
+
+from . import JobStore
+
+
+class ApiJobStore(JobStore):
+    def __init__(
+        self,
+        *,
+        http_client: aiohttp.ClientSession,
+        base_url: str,
+        job_id: int,
+        **kwargs: Any
+    ) -> None:
+        self.http_client = http_client
+        self.job_id = job_id
+        self.base_url = base_url
+        self.logger = getLogger(__name__, self)
+
+        self.after: Optional[str] = None
+        self.throttle_save_cursor = DelayedThrottle(self.delayed_save_cursor, delay=1)
+
+    async def load_cursor(self) -> Optional[str]:
+        job_url = urlcat(self.base_url, "api/jobs", str(self.job_id))
+        async with self.http_client.get(job_url) as response:
+            return fromdict(await response.json(), JobResponse).data.cursor
+
+    async def save_cursor(self, *, after: str) -> None:
+        self.after = after
+        await self.throttle_save_cursor(after=self.after)
+
+    async def delayed_save_cursor(self, *, after: str) -> None:
+        try:
+            job_url = urlcat(self.base_url, "api/jobs", str(self.job_id))
+            json = asdict(JobInput(cursor=after))
+            async with self.http_client.put(job_url, json=json) as response:
+                response.raise_for_status()
+        except Exception:
+            self.logger.exception("Failed to save cursor")

--- a/src/saturn_engine/worker/topics/memory.py
+++ b/src/saturn_engine/worker/topics/memory.py
@@ -52,7 +52,7 @@ class MemoryTopic(Topic):
         return True
 
 
-def get_queue(queue_id: str, *, maxsize: int = 10) -> asyncio.Queue:
+def get_queue(queue_id: str, *, maxsize: int = 100) -> asyncio.Queue:
     if queue_id not in _memory_queues:
         _memory_queues[queue_id] = asyncio.Queue(maxsize=maxsize)
     return _memory_queues[queue_id]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,13 @@ from sqlalchemy.orm import Session
 
 from saturn_engine import database
 
+from .utils import HttpClientMock
 from .utils import TimeForwardLoop
+
+
+@pytest.fixture
+def http_client_mock(event_loop: TimeForwardLoop) -> HttpClientMock:
+    return HttpClientMock(loop=event_loop)
 
 
 @pytest.fixture

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,17 @@
 import asyncio
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from selectors import DefaultSelector
 from typing import Any
 from typing import Callable
 from typing import Optional
+from typing import cast
+from unittest import mock
+from unittest.mock import Mock
+
+import aiohttp
+import yarl
 
 
 # From https://github.com/spulec/freezegun/issues/290
@@ -43,3 +52,131 @@ class TimeForwardLoop(asyncio.SelectorEventLoop):  # type: ignore
     async def wait_idle(self) -> None:
         await self.idled.wait()
         self.idled.clear()
+
+
+class FakeHttpClient:
+    def __init__(
+        self, *, responses: dict[str, dict[str, Mock]], loop: asyncio.AbstractEventLoop
+    ):
+        self.loop = loop
+        self.responses = responses
+
+        self.get = Mock(side_effect=self.response_context("get"))
+        self.post = Mock(side_effect=self.response_context("post"))
+        self.put = Mock(side_effect=self.response_context("put"))
+
+    def response_context(self, method: str) -> Callable:
+        @asynccontextmanager
+        async def request(url: str, *args: Any, **kwargs: Any) -> AsyncIterator:
+            response = self.responses[method][url](*args, **kwargs)
+            obj = self.make_response(method, url, response)
+            yield obj
+
+        return request
+
+    def make_response(
+        self, method: str, url: str, response: Any
+    ) -> aiohttp.ClientResponse:
+        if isinstance(response, aiohttp.ClientResponse):
+            return response
+        elif isinstance(response, dict):
+            return self.make_json_response(method=method, url=url, response=response)
+        elif isinstance(response, str):
+            return self.make_text_response(method=method, url=url, response=response)
+        elif isinstance(response, bytes):
+            return self.make_raw_response(method=method, url=url, response=response)
+        raise ValueError(f"Invalid response type: {response.__class__}")
+
+    def make_json_response(
+        self,
+        *,
+        method: str,
+        url: str,
+        response: dict,
+        headers: Optional[dict[str, str]] = None,
+        status: int = 200,
+        reason: str = "OK",
+    ) -> aiohttp.ClientResponse:
+        return self.make_text_response(
+            method=method,
+            url=url,
+            response=json.dumps(response),
+            headers={"Content-Type": "application/json"} | (headers or {}),
+            status=status,
+            reason=reason,
+        )
+
+    def make_text_response(
+        self,
+        *,
+        method: str,
+        url: str,
+        response: str,
+        headers: Optional[dict[str, str]] = None,
+        status: int = 200,
+        reason: str = "OK",
+    ) -> aiohttp.ClientResponse:
+        return self.make_raw_response(
+            method=method,
+            url=url,
+            response=response.encode(),
+            headers=headers,
+            status=status,
+            reason=reason,
+        )
+
+    def make_raw_response(
+        self,
+        *,
+        method: str,
+        url: str,
+        response: bytes,
+        headers: Optional[dict[str, str]] = None,
+        status: int = 200,
+        reason: str = "OK",
+    ) -> aiohttp.ClientResponse:
+        response_obj = aiohttp.ClientResponse(
+            method,
+            yarl.URL(url),
+            request_info=mock.Mock(),
+            writer=None,  # type: ignore
+            continue100=None,
+            timer=None,  # type: ignore
+            traces=[],
+            loop=self.loop,
+            session=None,  # type: ignore
+        )
+        response_obj._body = response
+        response_obj._headers = headers or {}  # type: ignore
+        response_obj.status = status
+        response_obj.reason = reason
+        return response_obj
+
+
+class HttpClientMock:
+    def __init__(self, *, loop: asyncio.AbstractEventLoop):
+        self.loop = loop
+        self.responses: dict[str, dict[str, Mock]] = {
+            "get": {},
+            "post": {},
+            "put": {},
+        }
+
+    def get(self, path: str) -> Mock:
+        return self.set_mock("get", path)
+
+    def put(self, path: str) -> Mock:
+        return self.set_mock("put", path)
+
+    def post(self, path: str) -> Mock:
+        return self.set_mock("post", path)
+
+    def set_mock(self, method: str, path: str) -> Mock:
+        self.responses[method].setdefault(path, Mock())
+        return self.responses[method][path]
+
+    def client(self) -> aiohttp.ClientSession:
+        return cast(
+            aiohttp.ClientSession,
+            FakeHttpClient(responses=self.responses, loop=self.loop),
+        )

--- a/tests/worker/job/test_api.py
+++ b/tests/worker/job/test_api.py
@@ -1,0 +1,40 @@
+import asyncio
+
+import pytest
+
+from saturn_engine.worker.job.api import ApiJobStore
+from tests.utils import HttpClientMock
+
+
+@pytest.mark.asyncio
+async def test_api_jobstore(http_client_mock: HttpClientMock) -> None:
+    http_client_mock.get("/api/jobs/1").return_value = {
+        "data": {"id": 1, "cursor": None}
+    }
+
+    job_store = ApiJobStore(
+        http_client=http_client_mock.client(),
+        base_url="",
+        job_id=1,
+    )
+
+    assert await job_store.load_cursor() is None
+
+    http_client_mock.get("/api/jobs/1").return_value = {
+        "data": {"id": 1, "cursor": "10"}
+    }
+    assert await job_store.load_cursor() == "10"
+
+    http_client_mock.put("/api/jobs/1").return_value = {}
+    await job_store.save_cursor(after="20")
+    http_client_mock.put("/api/jobs/1").assert_not_called()
+
+    await asyncio.sleep(0.5)
+    await job_store.save_cursor(after="30")
+    http_client_mock.put("/api/jobs/1").assert_not_called()
+
+    await asyncio.sleep(0.6)
+    http_client_mock.put("/api/jobs/1").assert_called_once_with(json={"cursor": "30"})
+
+    await asyncio.sleep(1.1)
+    http_client_mock.put("/api/jobs/1").assert_called_once_with(json={"cursor": "30"})


### PR DESCRIPTION
This job store also ensure we call the API at most once per second (Could probably make it even nicer).