### PR TITLE
worker(topic): limit publish concurrency

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,6 +53,12 @@ class TimeForwardLoop(asyncio.SelectorEventLoop):  # type: ignore
         await self.idled.wait()
         self.idled.clear()
 
+    @asynccontextmanager
+    async def until_idle(self) -> AsyncIterator[None]:
+        self.idled.clear()
+        yield
+        await self.wait_idle()
+
 
 class FakeHttpClient:
     def __init__(

--- a/tests/worker/test_resources_manager.py
+++ b/tests/worker/test_resources_manager.py
@@ -74,13 +74,13 @@ async def test_resources_manager_acquire_many(event_loop: TimeForwardLoop) -> No
     # Philosopher 1 lock r1 and r2.
     # Philosopher 2 lock r2 and r3
     # Philosopher 3 lock r3 and r1
-    philosophers = {
-        asyncio.create_task(resources_manager.acquire_many(["R1", "R2"])),
-        asyncio.create_task(resources_manager.acquire_many(["R2", "R3"])),
-        asyncio.create_task(resources_manager.acquire_many(["R3", "R4"])),
-        asyncio.create_task(resources_manager.acquire_many(["R4", "R1"])),
-    }
-    await event_loop.wait_idle()
+    async with event_loop.until_idle():
+        philosophers = {
+            asyncio.create_task(resources_manager.acquire_many(["R1", "R2"])),
+            asyncio.create_task(resources_manager.acquire_many(["R2", "R3"])),
+            asyncio.create_task(resources_manager.acquire_many(["R3", "R4"])),
+            asyncio.create_task(resources_manager.acquire_many(["R4", "R1"])),
+        }
 
     # All resource should be locked.
     for i in range(1, 5):

--- a/tests/worker/test_topics.py
+++ b/tests/worker/test_topics.py
@@ -1,3 +1,5 @@
+import asyncio
+import threading
 from typing import Optional
 
 import asyncstdlib as alib
@@ -5,13 +7,17 @@ import pytest
 
 from saturn_engine.core import TopicMessage
 from saturn_engine.worker.topics import BlockingTopic
+from tests.utils import TimeForwardLoop
 
 
 @pytest.mark.asyncio
-async def test_blocking_topic() -> None:
+async def test_blocking_topic(event_loop: TimeForwardLoop) -> None:
+    event = threading.Event()
+
     class FakeTopic(BlockingTopic):
         def __init__(self) -> None:
-            self.published: list[tuple[TopicMessage, bool]] = []
+            super().__init__()
+            self.published: list[str] = []
             self.x = 0
 
         def run_once_blocking(self) -> Optional[TopicMessage]:
@@ -21,8 +27,13 @@ async def test_blocking_topic() -> None:
             return TopicMessage(id=str(self.x), args={})
 
         def publish_blocking(self, message: TopicMessage, wait: bool) -> bool:
-            self.published.append((message, wait))
-            return wait
+            if message.args["block"]:
+                if wait:
+                    event.wait()
+                else:
+                    return False
+            self.published.append(message.id)
+            return True
 
     topic = FakeTopic()
 
@@ -30,9 +41,27 @@ async def test_blocking_topic() -> None:
         TopicMessage(id="1", args={}),
         TopicMessage(id="2", args={}),
     ]
-    assert await topic.publish(TopicMessage(id="1", args={}), wait=True)
-    assert not await topic.publish(TopicMessage(id="2", args={}), wait=False)
-    assert topic.published == [
-        (TopicMessage(id="1", args={}), True),
-        (TopicMessage(id="2", args={}), False),
-    ]
+
+    assert await topic.publish(TopicMessage(id="1", args={"block": False}), wait=True)
+    assert await topic.publish(TopicMessage(id="2", args={"block": False}), wait=False)
+    assert not await topic.publish(
+        TopicMessage(id="3", args={"block": True}), wait=False
+    )
+
+    async with event_loop.until_idle():
+        publish_task1 = asyncio.create_task(
+            topic.publish(TopicMessage(id="4", args={"block": True}), wait=True)
+        )
+
+    assert not await topic.publish(
+        TopicMessage(id="5", args={"block": False}), wait=False
+    )
+    publish_task2 = asyncio.create_task(
+        topic.publish(TopicMessage(id="6", args={"block": False}), wait=True)
+    )
+
+    event.set()
+    assert await publish_task1
+    assert await publish_task2
+
+    assert topic.published == ["1", "2", "4", "6"]


### PR DESCRIPTION
This way we don't starve the thread pool in case a pipeline is spamming publish (And we can apply back pressure on the queue)