### PR TITLE
worker-manager(declaratives): Makes options optional

### DIFF
--- a/src/saturn_engine/worker_manager/config/declarative_inventory.py
+++ b/src/saturn_engine/worker_manager/config/declarative_inventory.py
@@ -9,7 +9,7 @@ from .declarative_base import BaseObject
 @dataclasses.dataclass
 class InventorySpec:
     type: str
-    options: dict[str, Any]
+    options: dict[str, Any] = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass

--- a/src/saturn_engine/worker_manager/config/declarative_topic_item.py
+++ b/src/saturn_engine/worker_manager/config/declarative_topic_item.py
@@ -9,7 +9,7 @@ from .declarative_base import BaseObject
 @dataclasses.dataclass
 class TopicSpec:
     type: str
-    options: dict[str, Any]
+    options: dict[str, Any] = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass

--- a/tests/worker_manager/config/test_declarative.py
+++ b/tests/worker_manager/config/test_declarative.py
@@ -41,7 +41,6 @@ metadata:
   name: test-topic
 spec:
   type: RabbitMQ
-  options: {}
 ---
 apiVersion: saturn.github.io/v1alpha1
 kind: SaturnInventory


### PR DESCRIPTION
A small life improvement, got an error about missing `options` attribute in my yaml file. Could be made optional if options is empty.