### PR TITLE
dev: make project locally installable with pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 /test.db
 /.venv-tools
 /dist
+*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ profile = "black"
 force_single_line = true
 
 [build-system]
-requires = ["poetry_core>=1.0.0"]
+requires = ["poetry_core>=1.0.0", "setuptools"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import find_packages
+from setuptools import setup
+
+setup(
+    name="saturn_engine",
+    version="0.3dev",
+    packages=["saturn_engine"],
+    package_dir={"":"src"},
+    install_requires=[],
+)


### PR DESCRIPTION
Makes it possible to install the project with `pip install -e $saturn_pwd`. Next poetry release will support doing it without setuptools, but for now that's very useful.
