### PR TITLE
ENV -> SATURN_ENV

### DIFF
--- a/src/saturn_engine/worker/services/config.py
+++ b/src/saturn_engine/worker/services/config.py
@@ -32,7 +32,7 @@ class ConfigService:
     _config: Type[BaseConfig]
 
     def __init__(self) -> None:
-        env = Env(os.environ["ENV"])
+        env = Env(os.environ["SATURN_ENV"])
         if env is Env.TEST:
             self._config = TestConfig
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ from .utils import TimeForwardLoop
 
 
 def pytest_configure() -> None:
-    os.environ["ENV"] = "test"
+    os.environ["SATURN_ENV"] = "test"
 
 
 @pytest.fixture


### PR DESCRIPTION
This conflicts with you-know-what's legacy env var names, and we should use the `SATURN_` prefix like other env vars.