### PR TITLE
saturn(services): Complete the services API.

### DIFF
--- a/src/saturn_engine/config.py
+++ b/src/saturn_engine/config.py
@@ -9,7 +9,8 @@ from .utils.config import Config as _Config
 
 class Config(_Config[SaturnConfig]):
     def __init__(self) -> None:
-        super().__init__(SaturnConfig)
+        super().__init__()
+        self._interfaces[""] = SaturnConfig
 
 
 __all__ = (

--- a/src/saturn_engine/config_definitions.py
+++ b/src/saturn_engine/config_definitions.py
@@ -1,3 +1,4 @@
+import dataclasses
 from enum import Enum
 
 
@@ -7,21 +8,29 @@ class Env(Enum):
     PRODUCTION = "production"
 
 
+@dataclasses.dataclass
 class WorkerConfig:
     job_store_cls: str
     executor_cls: str
     worker_manager_url: str
+    services: list[str]
+    # Check services type dependancies match loaded services. `False` value is
+    # needed to load fake services.
+    strict_services: bool
 
 
+@dataclasses.dataclass
 class RabbitMQConfig:
     url: str
 
 
+@dataclasses.dataclass
 class RayConfig:
     local: bool
     address: str
 
 
+@dataclasses.dataclass
 class SaturnConfig:
     env: Env
     worker: WorkerConfig

--- a/src/saturn_engine/core/pipeline.py
+++ b/src/saturn_engine/core/pipeline.py
@@ -21,7 +21,7 @@ class PipelineInfo:
 
     @classmethod
     def from_pipeline(cls, pipeline: Callable) -> "PipelineInfo":
-        name = extra_inspect.get_import_names(pipeline)
+        name = extra_inspect.get_import_name(pipeline)
         try:
             signature = extra_inspect.signature(pipeline)
         except Exception as e:

--- a/src/saturn_engine/default_config.py
+++ b/src/saturn_engine/default_config.py
@@ -16,6 +16,8 @@ class config(SaturnConfig):
         worker_manager_url = os.environ.get(
             "SATURN_WORKER_MANAGER_URL", "http://localhost:5000"
         )
+        services = ["saturn_engine.worker.services.rabbitmq.RabbitMQService"]
+        strict_services = True
 
     class rabbitmq(RabbitMQConfig):
         url = os.environ.get("SATURN_AMQP_URL", "amqp://127.0.0.1/")

--- a/src/saturn_engine/utils/__init__.py
+++ b/src/saturn_engine/utils/__init__.py
@@ -1,3 +1,4 @@
+import collections
 import enum
 import threading
 from collections.abc import Iterable
@@ -165,3 +166,25 @@ def default_utc(date: datetime) -> datetime:
     if date.tzinfo is None:
         return date.replace(tzinfo=timezone.utc)
     return date
+
+
+class Namespace(collections.UserDict):
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self.data[name]
+        except KeyError:
+            raise AttributeError(name) from None
+
+
+class CINamespace(collections.UserDict):
+    def __getattr__(self, name: str) -> Any:
+        try:
+            return self.data[name.lower()]
+        except KeyError:
+            raise AttributeError(name) from None
+
+    def __getitem__(self, name: str) -> Any:
+        return self.data[name.lower()]
+
+    def __setitem__(self, name: str, value: Any) -> None:
+        self.data[name.lower()] = value

--- a/src/saturn_engine/utils/inspect.py
+++ b/src/saturn_engine/utils/inspect.py
@@ -59,7 +59,7 @@ def eval_class_annotations(
 
 
 # Taken from CPython pickle.py
-def get_import_names(obj: Callable) -> str:
+def get_import_name(obj: Callable) -> str:
     name = getattr(obj, "__qualname__", None)
     if name is None:
         name = obj.__name__

--- a/src/saturn_engine/worker/executors/__init__.py
+++ b/src/saturn_engine/worker/executors/__init__.py
@@ -2,12 +2,12 @@ import asyncio
 from abc import abstractmethod
 from typing import Type
 
-from saturn_engine.config import Config
 from saturn_engine.core import PipelineOutput
 from saturn_engine.core import PipelineResult
 from saturn_engine.utils.inspect import import_name
 from saturn_engine.utils.log import getLogger
 from saturn_engine.worker.pipeline_message import PipelineMessage
+from saturn_engine.worker.services import Services
 
 from ..executable_message import ExecutableMessage
 from ..resources_manager import ResourcesManager
@@ -15,7 +15,7 @@ from ..resources_manager import ResourceUnavailable
 
 
 class Executor:
-    def __init__(self, config: Config) -> None:
+    def __init__(self, services: Services) -> None:
         pass
 
     @abstractmethod

--- a/src/saturn_engine/worker/executors/process.py
+++ b/src/saturn_engine/worker/executors/process.py
@@ -4,7 +4,7 @@ from functools import partial
 
 from saturn_engine.core import PipelineResult
 from saturn_engine.worker.pipeline_message import PipelineMessage
-from saturn_engine.worker.services.manager import ServicesManager
+from saturn_engine.worker.services import Services
 
 from . import Executor
 from .bootstrap import bootstrap_pipeline
@@ -19,7 +19,7 @@ def process_initializer() -> None:
 
 
 class ProcessExecutor(Executor):
-    def __init__(self, services: ServicesManager) -> None:
+    def __init__(self, services: Services) -> None:
         self.pool_executor = concurrent.futures.ProcessPoolExecutor(
             initializer=process_initializer
         )

--- a/src/saturn_engine/worker/executors/ray.py
+++ b/src/saturn_engine/worker/executors/ray.py
@@ -5,7 +5,7 @@ import ray
 from saturn_engine.core import PipelineResult
 from saturn_engine.worker.pipeline_message import PipelineMessage
 
-from ..services.manager import ServicesManager
+from ..services import Services
 from . import Executor
 from .bootstrap import bootstrap_pipeline
 
@@ -16,7 +16,7 @@ def ray_execute(message: PipelineMessage) -> PipelineResult:
 
 
 class RayExecutor(Executor):
-    def __init__(self, services: ServicesManager) -> None:
+    def __init__(self, services: Services) -> None:
         options: dict[str, Any] = {
             "local_mode": services.config.c.ray.local,
         }

--- a/src/saturn_engine/worker/runner.py
+++ b/src/saturn_engine/worker/runner.py
@@ -10,9 +10,7 @@ from .broker import Broker
 
 async def async_main() -> None:
     loop = asyncio.get_running_loop()
-    config = Config()
-    config.load_object(default_config)
-    config.load_envvar("SATURN_SETTINGS")
+    config = Config().load_object(default_config).load_envvar("SATURN_SETTINGS")
     broker = Broker(config)
     for signame in ["SIGINT", "SIGTERM"]:
         loop.add_signal_handler(getattr(signal, signame), broker.stop)

--- a/src/saturn_engine/worker/services/__init__.py
+++ b/src/saturn_engine/worker/services/__init__.py
@@ -1,0 +1,88 @@
+import typing
+from typing import Any
+from typing import ClassVar
+from typing import Generic
+from typing import Optional
+from typing import Type
+from typing import TypeVar
+from typing import cast
+
+from saturn_engine.config import Config
+from saturn_engine.utils import Namespace
+from saturn_engine.utils import inspect as extra_inspect
+from saturn_engine.utils.config import Config as BaseConfig
+
+__all__ = ("Config", "Service", "BaseServices")
+
+
+class BaseServices:
+    config: Config
+
+
+TServices = TypeVar("TServices", bound=BaseServices)
+TOptions = TypeVar("TOptions")
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+class Service(Generic[TServices, TOptions]):
+    name: ClassVar[str]
+    Services: ClassVar[Optional[Type[TServices]]] = None
+    Options: ClassVar[Optional[Type[TOptions]]] = None
+
+    def __init__(self, services: TServices):
+        self.services: TServices = services
+
+    @property
+    def options(self) -> TOptions:
+        if self.Options is None:
+            raise ValueError("No options defined.")
+        return self.services.config.cast_namespace(self.name, self.Options)
+
+    async def open(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+TService = TypeVar("TService", bound=Service)
+
+MinimalService = Service[BaseServices, None]
+
+
+class ServicesNamespace(Namespace, Generic[T]):
+    def __init__(self, *args: Any, strict: bool, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.strict = strict
+        self.s: T = cast(T, self)
+
+    def cast(self, interface: Type[U]) -> "ServicesNamespace[U]":
+        services_annotations = typing.get_type_hints(interface)
+        for service in services_annotations.values():
+            self.cast_service(service)
+        return cast(ServicesNamespace[U], self)
+
+    def cast_service(self, service_cls: Type[TService]) -> TService:
+        # Config is a special case (Doesn't subclass Service).
+        if issubclass(service_cls, BaseConfig):
+            return self["config"]
+
+        name = service_cls.name
+        typ_import_name = extra_inspect.get_import_name(service_cls)
+        service = self.get(name)
+        if not service:
+            raise ValueError(f"Namespace missing '{typ_import_name}' service")
+
+        if self.strict and service_cls is not service.__class__:
+            dependency_name = extra_inspect.get_import_name(service.__class__)
+            raise ValueError(
+                f"Service '{name}' expected to be '{typ_import_name}', "
+                f"got '{dependency_name}'"
+            )
+
+        return cast(TService, service)
+
+
+Services = ServicesNamespace[BaseServices]

--- a/src/saturn_engine/worker/services/http_client.py
+++ b/src/saturn_engine/worker/services/http_client.py
@@ -1,8 +1,12 @@
 import aiohttp
 
+from . import MinimalService
 
-class HttpClient:
-    def __init__(self) -> None:
+
+class HttpClient(MinimalService):
+    name = "http_client"
+
+    async def open(self) -> None:
         self.session = aiohttp.ClientSession()
 
     async def close(self) -> None:

--- a/src/saturn_engine/worker/services/job_store.py
+++ b/src/saturn_engine/worker/services/job_store.py
@@ -3,12 +3,16 @@ from saturn_engine.worker.job import JobStore
 from saturn_engine.worker.job.api import ApiJobStore
 from saturn_engine.worker.job.memory import MemoryJobStore
 
-from .manager import ServicesManager
+from . import BaseServices
+from . import Service
+from .http_client import HttpClient
 
 
-class JobStoreService:
-    def __init__(self, services: ServicesManager) -> None:
-        self.services = services
+class JobStoreService(Service["JobStoreService.Services", None]):
+    name = "job_store"
+
+    class Services(BaseServices):
+        http_client: HttpClient
 
     def for_queue(self, queue: QueueItem) -> JobStore:
         klass = self.services.config.c.worker.job_store_cls

--- a/src/saturn_engine/worker/services/manager.py
+++ b/src/saturn_engine/worker/services/manager.py
@@ -1,17 +1,70 @@
-from saturn_engine.config import Config
+from typing import Type
+
+from saturn_engine.utils import inspect as extra_inspect
+
+from . import BaseServices
+from . import Config
+from . import Service
+from . import Services
+from . import ServicesNamespace
+from . import TService
 
 
 class ServicesManager:
     def __init__(self, config: Config) -> None:
-        from .http_client import HttpClient
-        from .job_store import JobStoreService
-        from .rabbitmq import RabbitMQService
+        self.services: Services = ServicesNamespace(config=config, strict=True)
+        self.loaded_services: list[Service] = []
+        self.strict = config.c.worker.strict_services
+        self.is_opened = False
 
-        self.config = config
-        self.rabbitmq = RabbitMQService(self)
-        self.http_client = HttpClient()
-        self.job_store = JobStoreService(self)
+        # Some services are required for saturn to work at all.
+        for service_cls in BASE_SERVICES:
+            self._load_service(service_cls)
+
+        # Load optional services based on config.
+        for service_cls_path in config.c.worker.services:
+            service_cls = extra_inspect.import_name(service_cls_path)
+            self._load_service(service_cls)
+
+    async def open(self) -> None:
+        for service in self.loaded_services:
+            await service.open()
+        self.is_opened = True
 
     async def close(self) -> None:
-        await self.rabbitmq.close()
-        await self.http_client.close()
+        if not self.is_opened:
+            return
+        for service in reversed(self.loaded_services):
+            await service.close()
+
+    def _load_service(self, service_cls: Type[TService]) -> None:
+        if service_cls.name in self.services:
+            raise ValueError(f"Cannot load '{service_cls.name}' twice")
+
+        if service_cls.Options:
+            try:
+                self.services["config"] = self.services.s.config.register_interface(
+                    service_cls.name, service_cls.Options
+                )
+            except Exception as e:
+                raise ValueError(
+                    f"Invalid service '{service_cls.name}' configuration"
+                ) from e
+
+        try:
+            service = service_cls(
+                self.services.cast(service_cls.Services or BaseServices)
+            )
+        except Exception as e:
+            raise ValueError(f"Failed to load service '{service_cls.name}'") from e
+        self.loaded_services.append(service)
+        self.services[service_cls.name] = service
+
+
+from .http_client import HttpClient
+from .job_store import JobStoreService
+
+BASE_SERVICES: list[Type[Service]] = [
+    HttpClient,
+    JobStoreService,
+]

--- a/src/saturn_engine/worker/services/rabbitmq.py
+++ b/src/saturn_engine/worker/services/rabbitmq.py
@@ -3,12 +3,11 @@ import asyncstdlib as alib
 
 from saturn_engine.utils import get_own_attr
 
-from .manager import ServicesManager
+from . import MinimalService
 
 
-class RabbitMQService:
-    def __init__(self, services: ServicesManager) -> None:
-        self.services = services
+class RabbitMQService(MinimalService):
+    name = "rabbitmq"
 
     @alib.cached_property
     async def connection(self) -> aio_pika.Connection:

--- a/src/saturn_engine/worker/topics/rabbitmq.py
+++ b/src/saturn_engine/worker/topics/rabbitmq.py
@@ -8,7 +8,8 @@ from aio_pika import IncomingMessage
 
 from saturn_engine.core import TopicMessage
 from saturn_engine.utils.log import getLogger
-from saturn_engine.worker.services.manager import ServicesManager
+from saturn_engine.worker.services import Services
+from saturn_engine.worker.services.rabbitmq import RabbitMQService
 
 from . import Topic
 from . import TopicOutput
@@ -21,12 +22,13 @@ class RabbitMQTopic(Topic):
     class Options:
         queue_name: str
 
-    def __init__(
-        self, options: Options, services: ServicesManager, **kwargs: object
-    ) -> None:
+    class TopicServices:
+        rabbitmq: RabbitMQService
+
+    def __init__(self, options: Options, services: Services, **kwargs: object) -> None:
         self.logger = getLogger(__name__, self)
         self.options = options
-        self.services = services
+        self.services = services.cast(RabbitMQTopic.TopicServices)
 
     async def run(self) -> AsyncGenerator[TopicOutput, None]:
         self.logger.info("Starting queue %s", self.options.queue_name)

--- a/src/saturn_engine/worker/work_factory.py
+++ b/src/saturn_engine/worker/work_factory.py
@@ -11,14 +11,14 @@ from . import topics
 from .inventories import Inventory
 from .job import Job
 from .queue import ExecutableQueue
-from .services.manager import ServicesManager
+from .services import Services
 from .topics import Topic
 from .topics.memory import MemoryTopic
 from .work import SchedulableQueue
 from .work import WorkItems
 
 
-def build(queue_item: QueueItem, *, services: ServicesManager) -> WorkItems:
+def build(queue_item: QueueItem, *, services: Services) -> WorkItems:
     task: Optional[asyncio.Task] = None
     if isinstance(queue_item.input, TopicItem):
         queue_input = build_topic(queue_item.input, services=services)
@@ -44,7 +44,7 @@ def build(queue_item: QueueItem, *, services: ServicesManager) -> WorkItems:
     )
 
 
-def build_topic(topic_item: TopicItem, *, services: ServicesManager) -> Topic:
+def build_topic(topic_item: TopicItem, *, services: Services) -> Topic:
     klass = topics.BUILTINS.get(topic_item.type)
     if klass is None:
         klass = extra_inspect.import_name(topic_item.type)
@@ -57,7 +57,7 @@ def build_topic(topic_item: TopicItem, *, services: ServicesManager) -> Topic:
 
 
 def build_inventory(
-    inventory_item: InventoryItem, *, queue_item: QueueItem, services: ServicesManager
+    inventory_item: InventoryItem, *, queue_item: QueueItem, services: Services
 ) -> tuple[asyncio.Task, Topic]:
     klass = inventories.BUILTINS.get(inventory_item.type)
     if klass is None:

--- a/src/saturn_engine/worker/work_manager.py
+++ b/src/saturn_engine/worker/work_manager.py
@@ -18,7 +18,7 @@ from saturn_engine.utils.log import getLogger
 from saturn_engine.worker.resources_manager import ResourceData
 
 from . import work_factory
-from .services.manager import ServicesManager
+from .services import Services
 from .work import SchedulableQueue
 from .work import WorkItems
 
@@ -90,7 +90,7 @@ class WorkManager:
     last_sync_at: Optional[datetime]
 
     def __init__(
-        self, *, services: ServicesManager, client: Optional[WorkerManagerClient] = None
+        self, *, services: Services, client: Optional[WorkerManagerClient] = None
     ) -> None:
         self.logger = getLogger(__name__, self)
         self.client = client or WorkerManagerClient(

--- a/tests/config.py
+++ b/tests/config.py
@@ -9,6 +9,7 @@ class config(SaturnConfig):
 
     class worker(WorkerConfig):
         job_store_cls = "MemoryJobStore"
+        strict_services = False
 
     class ray(RayConfig):
         local = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,4 @@ def job_definition_maker(
 
 @pytest.fixture(scope="session")
 def config() -> Config:
-    config = Config()
-    config.load_object(default_config)
-    config.load_object(test_config)
-    return config
+    return Config().load_objects([default_config, test_config])

--- a/tests/worker/test_services_manager.py
+++ b/tests/worker/test_services_manager.py
@@ -1,0 +1,183 @@
+import dataclasses
+from typing import Optional
+
+import pytest
+
+from saturn_engine.config import Config
+from saturn_engine.utils.inspect import get_import_name
+from saturn_engine.worker.services import BaseServices
+from saturn_engine.worker.services import MinimalService
+from saturn_engine.worker.services import Service
+from saturn_engine.worker.services.manager import ServicesManager
+
+
+class FakeServiceWithConfig(Service[BaseServices, "FakeServiceWithConfig.Options"]):
+    name = "fake_with_config"
+
+    @dataclasses.dataclass
+    class Options:
+        a: int
+
+
+class FakestService(MinimalService):
+    name = "fake_with_config"
+
+
+class FakeServiceWithServices(Service[BaseServices, None]):
+    name = "fake_with_services"
+
+    class Services:
+        fake_with_config: FakeServiceWithConfig
+
+
+class FakeService(Service["FakeService.Services", "FakeService.Options"]):
+    name = "fake"
+
+    class Services(BaseServices):
+        config: Config
+        fake_with_config: FakeServiceWithConfig
+
+    @dataclasses.dataclass
+    class Options:
+        b: int
+
+    state: Optional[str] = None
+
+    async def open(self) -> None:
+        assert self.services.fake_with_config.options.a is not None
+        assert self.options.b is not None
+
+        self.state = "opened"
+
+    async def close(self) -> None:
+        self.state = "closed"
+
+
+@pytest.mark.asyncio
+async def test_services_manager(config: Config) -> None:
+    config = config.load_object(
+        {
+            "worker": {
+                "services": [
+                    get_import_name(FakeServiceWithConfig),
+                    get_import_name(FakeService),
+                ],
+            },
+            "fake_with_config": {"a": 1},
+            "fake": {"b": 2},
+        }
+    )
+    sm = ServicesManager(config)
+
+    class FakeServices:
+        fake: FakeService
+        fake_with_config: FakeServiceWithConfig
+
+    services = sm.services.cast(FakeServices)
+    assert services.fake_with_config.options.a == 1
+    assert services.fake.options.b == 2
+    assert services.fake.state is None
+
+    # Service Manager register service options to config.
+    assert sm.services.config.cast_namespace("fake", FakeService.Options).b == 2
+
+    await sm.open()
+    assert services.fake.state == "opened"
+    await sm.close()
+    assert services.fake.state == "closed"
+
+
+def test_services_manager_check_options(config: Config) -> None:
+    # Loading a services expecting config requires config.
+    config = config.load_object(
+        {
+            "worker": {
+                "services": [
+                    get_import_name(FakeServiceWithConfig),
+                ],
+            },
+        }
+    )
+    with pytest.raises(
+        ValueError, match="Invalid service 'fake_with_config' configuration"
+    ):
+        ServicesManager(config)
+
+    # But the config must also be valid
+    config = config.load_object({"fake_with_config": {"a": "foo"}})
+    with pytest.raises(
+        ValueError, match="Invalid service 'fake_with_config' configuration"
+    ):
+        ServicesManager(config)
+
+    # Finally, load if the config is right.
+    config = config.load_object({"fake_with_config": {"a": 1}})
+    ServicesManager(config)
+
+    # Cannot load a service twice.
+    config = config.load_object(
+        {
+            "worker": {
+                "services": [
+                    get_import_name(FakeServiceWithConfig),
+                    get_import_name(FakeServiceWithConfig),
+                ],
+            },
+        }
+    )
+    with pytest.raises(ValueError, match="Cannot load 'fake_with_config' twice"):
+        ServicesManager(config)
+
+
+def test_services_manager_check_services(config: Config) -> None:
+    # Loading a services expecting other services require these service to be loaded.
+    config = config.load_object(
+        {
+            "worker": {
+                "services": [
+                    get_import_name(FakeServiceWithServices),
+                ],
+                # Enable strict mode to validate it works.
+                "strict_services": True,
+            },
+        }
+    )
+    with pytest.raises(
+        ValueError,
+        match="Failed to load service 'fake_with_services'",
+    ):
+        ServicesManager(config)
+
+    config = config.load_object(
+        {
+            "worker": {
+                "services": [
+                    get_import_name(FakestService),
+                    get_import_name(FakeServiceWithServices),
+                ],
+            },
+        }
+    )
+    with pytest.raises(
+        ValueError,
+        match="Failed to load service 'fake_with_services'",
+    ):
+        ServicesManager(config)
+
+    config = config.load_object(
+        {
+            "worker": {
+                "services": [
+                    get_import_name(FakeServiceWithConfig),
+                    get_import_name(FakeServiceWithServices),
+                ],
+            },
+            "fake_with_config": {"a": 1},
+        }
+    )
+    ServicesManager(config)
+
+
+def test_default_services(config: Config) -> None:
+    ServicesManager(config)
+    assert True


### PR DESCRIPTION
This got a big bigger than I expected. My goal was to create some system to safely (as in typed safety) load arbitrary services/extensions.

So my end result is an extensions interface such as:

```python
class MalamuteService:
  class Services:
    logging: Logging
    config: Config

  class Options:
    broker_url: str

  async def open(self):
     self.connection = await self.connect(self.options.broker_url)

  async def close(self):
    await self.connection.close()

class MalamuteTopic:
  class MalamuteServices:
    malamute: MalamuteService

  def __init__(self, services: Services):
    self.connection = services.cast(MalamuteServices).malamute.connection
```

Everything above is guarantee to works. The services is only loaded if the loaded config is valid for `Options` and if the `Services` are loaded. The Topic can only load if the `MalamuteService` is loaded.