### PR TITLE
Makefile: source venv before running nox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,31 @@
 
 .PHONY: nox
 nox: .venv-tools
-	.venv-tools/bin/nox
+	bash -c "\
+		source .venv-tools/bin/activate \
+		&& .venv-tools/bin/nox \
+	"
 
 .PHONY: nox-tests
 nox-tests: .venv-tools
-	.venv-tools/bin/nox -s tests
+	bash -c "\
+		source .venv-tools/bin/activate \
+		&& .venv-tools/bin/nox -s tests \
+	"
 
 .PHONY: nox-mypy
 nox-mypy: .venv-tools
-	.venv-tools/bin/nox -s mypy
+	bash -c "\
+		source .venv-tools/bin/activate \
+		&& .venv-tools/bin/nox -s mypy \
+	"
 
 .PHONY: nox-format
 nox-format: .venv-tools
-	.venv-tools/bin/nox -s format
+	bash -c "\
+		source .venv-tools/bin/activate \
+		&& .venv-tools/bin/nox -s format \
+	"
 
 .PHONY: clean
 clean:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ flake8-breakpoint = "^1.1.0"
 addopts = "--doctest-modules"
 filterwarnings = [
   "error",
+  "ignore:distutils Version classes are deprecated.:DeprecationWarning",
   "ignore::marshmallow.warnings.RemovedInMarshmallow4Warning",
 ]
 


### PR DESCRIPTION
Nox wouldn't find poetry from the venv if the env wasn't sourced
before executing it.