### PR TITLE
utils: create tester script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,13 @@ nox-tests: .venv-tools
 		&& .venv-tools/bin/nox -s tests \
 	"
 
+.PHONY: nox-tests-pipeline
+nox-tests-pipeline: .venv-tools
+	bash -c "\
+		source .venv-tools/bin/activate \
+		&& .venv-tools/bin/nox -s tests_pipeline \
+	"
+
 .PHONY: nox-mypy
 nox-mypy: .venv-tools
 	bash -c "\

--- a/example/definitions/simple.yaml
+++ b/example/definitions/simple.yaml
@@ -46,3 +46,14 @@ spec:
 
     pipeline:
       name: example.pipelines.echo
+      resources: {"api_key": "example.resources.TestApiKey"}
+---
+apiVersion: saturn.github.io/v1alpha1
+kind: SaturnResource
+metadata:
+  name: example-api-key
+spec:
+  type: example.resources.TestApiKey
+  data:
+    key: example-api-key-1
+  default_delay: 5

--- a/example/src/example/pipelines.py
+++ b/example/src/example/pipelines.py
@@ -2,7 +2,9 @@ from typing import Any
 
 from saturn_engine.core import TopicMessage
 
+from .resources import TestApiKey
 
-def echo(**kwargs: Any) -> TopicMessage:
-    print("echo: ", kwargs)
+
+def echo(api_key: TestApiKey, **kwargs: Any) -> TopicMessage:
+    print("api_key: ", api_key.key, "data: ", kwargs)
     return TopicMessage(args=kwargs)

--- a/example/src/example/resources.py
+++ b/example/src/example/resources.py
@@ -1,0 +1,8 @@
+import dataclasses
+
+from saturn_engine.core import Resource
+
+
+@dataclasses.dataclass
+class TestApiKey(Resource):
+    key: str

--- a/example/tests/pipeline_tests.yaml
+++ b/example/tests/pipeline_tests.yaml
@@ -1,0 +1,51 @@
+apiVersion: saturn.github.io/v1alpha1
+kind: SaturnPipelineTest
+metadata:
+  name: test-echo-pipeline
+spec:
+  selector:
+    job_definition: example-job-definition
+  inventory:
+    - message: override-1
+    - message: override-2
+    - message: override-3
+  resources:
+    example.resources.TestApiKey:
+      name: test-key-1
+      key: test
+  pipeline_results:
+    - outputs:
+        - channel: default
+          args:
+            message: override-1
+      resources: []
+    - outputs:
+        - channel: default
+          args:
+            message: override-2
+      resources: []
+    - outputs:
+        - channel: default
+          args:
+            message: override-3
+      resources: []
+---
+apiVersion: saturn.github.io/v1alpha1
+kind: SaturnPipelineTest
+metadata:
+  name: test-echo-pipeline-2
+spec:
+  selector:
+    job_definition: example-job-definition
+  inventory:
+    - message: second-test-hello
+  resources:
+    example.resources.TestApiKey:
+      name: test-key-1
+      key: test
+  pipeline_results:
+    - outputs:
+        - channel: default
+          args:
+            message: second-test-hello
+      resources: []

--- a/example/tests_pipeline
+++ b/example/tests_pipeline
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export PYTHONPATH="${PYTHONPATH}:$DIR/src"
+
+python -m saturn_engine.utils.tester \
+    --topology=example/definitions/simple.yaml \
+    --tests=example/tests/pipeline_tests.yaml

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ from typing import Sequence
 import nox
 from nox.sessions import Session
 
-nox.options.sessions = "lint", "mypy", "tests"
+nox.options.sessions = "lint", "mypy", "tests", "tests_pipeline"
 nox.options.reuse_existing_virtualenvs = True
 
 python_all_versions = ["3.9"]
@@ -55,6 +55,13 @@ def tests(session: Session) -> None:
     install_project(session)
     install_with_constraints(session, "pytest", "pytest-asyncio", "pytest-icdiff")
     session.run("pytest", "-vv", *args)
+
+
+@nox.session(python=python_all_versions)
+def tests_pipeline(session: Session) -> None:
+    args = session.posargs
+    install_project(session)
+    session.run("bash", "example/tests_pipeline", *args, external=True)
 
 
 @nox.session(python=python_all_versions)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1196,7 +1196,7 @@ worker-manager = ["Flask"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "b554a03b737b05abf5f1128b984432d3d7e879cad97c8b4e45e39c19938d3440"
+content-hash = "1b2c8c08eeecb02a57d20c43d314b4a24f95a54a33def1aa508c4e5794966e6f"
 
 [metadata.files]
 aio-pika = [
@@ -1626,6 +1626,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97e5306482182170ade15c4b0d8386ded995a07d7cc2ca8f27958d34d6736497"},
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6a36bb9474218c7a5b27ae476035497a6990e21d04c279884eb10d9b290f1b1"},
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abb7a75ed8b968f3061327c433a0fbd17b729947b400747c334a9c29a9af6c58"},
+    {file = "greenlet-1.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b336501a05e13b616ef81ce329c0e09ac5ed8c732d9ba7e3e983fcc1a9e86965"},
     {file = "greenlet-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:14d4f3cd4e8b524ae9b8aa567858beed70c392fdec26dbdb0a8a418392e71708"},
     {file = "greenlet-1.1.2-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:17ff94e7a83aa8671a25bf5b59326ec26da379ace2ebc4411d690d80a7fbcf23"},
     {file = "greenlet-1.1.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9f3cba480d3deb69f6ee2c1825060177a22c7826431458c697df88e6aeb3caee"},
@@ -1638,6 +1639,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9d29ca8a77117315101425ec7ec2a47a22ccf59f5593378fc4077ac5b754fce"},
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21915eb821a6b3d9d8eefdaf57d6c345b970ad722f856cd71739493ce003ad08"},
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff9d20417ff9dcb0d25e2defc2574d10b491bf2e693b4e491914738b7908168"},
+    {file = "greenlet-1.1.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b8c008de9d0daba7b6666aa5bbfdc23dcd78cafc33997c9b7741ff6353bafb7f"},
     {file = "greenlet-1.1.2-cp36-cp36m-win32.whl", hash = "sha256:32ca72bbc673adbcfecb935bb3fb1b74e663d10a4b241aaa2f5a75fe1d1f90aa"},
     {file = "greenlet-1.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:f0214eb2a23b85528310dad848ad2ac58e735612929c8072f6093f3585fd342d"},
     {file = "greenlet-1.1.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:b92e29e58bef6d9cfd340c72b04d74c4b4e9f70c9fa7c78b674d1fec18896dc4"},
@@ -1646,6 +1648,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e12bdc622676ce47ae9abbf455c189e442afdde8818d9da983085df6312e7a1"},
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8c790abda465726cfb8bb08bd4ca9a5d0a7bd77c7ac1ca1b839ad823b948ea28"},
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f276df9830dba7a333544bd41070e8175762a7ac20350786b322b714b0e654f5"},
+    {file = "greenlet-1.1.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c5d5b35f789a030ebb95bff352f1d27a93d81069f2adb3182d99882e095cefe"},
     {file = "greenlet-1.1.2-cp37-cp37m-win32.whl", hash = "sha256:64e6175c2e53195278d7388c454e0b30997573f3f4bd63697f88d855f7a6a1fc"},
     {file = "greenlet-1.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b11548073a2213d950c3f671aa88e6f83cda6e2fb97a8b6317b1b5b33d850e06"},
     {file = "greenlet-1.1.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:9633b3034d3d901f0a46b7939f8c4d64427dfba6bbc5a36b1a67364cf148a1b0"},
@@ -1654,6 +1657,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e859fcb4cbe93504ea18008d1df98dee4f7766db66c435e4882ab35cf70cac43"},
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711"},
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec8c433b3ab0419100bd45b47c9c8551248a5aee30ca5e9d399a0b57ac04651b"},
+    {file = "greenlet-1.1.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2bde6792f313f4e918caabc46532aa64aa27a0db05d75b20edfc5c6f46479de2"},
     {file = "greenlet-1.1.2-cp38-cp38-win32.whl", hash = "sha256:288c6a76705dc54fba69fbcb59904ae4ad768b4c768839b8ca5fdadec6dd8cfd"},
     {file = "greenlet-1.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:8d2f1fb53a421b410751887eb4ff21386d119ef9cde3797bf5e7ed49fb51a3b3"},
     {file = "greenlet-1.1.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:166eac03e48784a6a6e0e5f041cfebb1ab400b394db188c48b3a84737f505b67"},
@@ -1662,6 +1666,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1692f7d6bc45e3200844be0dba153612103db241691088626a33ff1f24a0d88"},
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7227b47e73dedaa513cdebb98469705ef0d66eb5a1250144468e9c3097d6b59b"},
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ff61ff178250f9bb3cd89752df0f1dd0e27316a8bd1465351652b1b4a4cdfd3"},
+    {file = "greenlet-1.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3"},
     {file = "greenlet-1.1.2-cp39-cp39-win32.whl", hash = "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf"},
     {file = "greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd"},
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-SQLAlchemy = {extras = ["mypy"], version = "^1.4.25"}
+SQLAlchemy = {extras = ["mypy"], version = "1.4.27"}
 aiosqlite = "^0.17.0"
 marshmallow = "^3.13.0"
 desert = "^2020.11.18"
@@ -38,6 +38,7 @@ croniter = "^1.0.15"
 types-croniter = "^1.0.3"
 marshmallow-enum = "^1.5.1"
 ray = {version = "^1.8.0", optional = true}
+click = "^8.0.3"
 
 [tool.poetry.extras]
 worker-manager = [

--- a/src/saturn_engine/utils/tester.py
+++ b/src/saturn_engine/utils/tester.py
@@ -1,0 +1,203 @@
+import dataclasses
+import os
+import shutil
+import sys
+from typing import Any
+
+import click
+import yaml
+
+from saturn_engine.core import TopicMessage
+from saturn_engine.utils.options import asdict
+from saturn_engine.utils.options import fromdict
+from saturn_engine.worker.executors.bootstrap import bootstrap_pipeline
+from saturn_engine.worker.pipeline_message import PipelineMessage
+from saturn_engine.worker_manager.config.declarative import (
+    load_definitions_from_directory,
+)
+from saturn_engine.worker_manager.config.declarative import load_definitions_from_str
+from saturn_engine.worker_manager.config.declarative_base import BaseObject
+from saturn_engine.worker_manager.config.static_definitions import StaticDefinitions
+
+
+@dataclasses.dataclass
+class ExpectedPipelineOutput:
+    channel: str
+    args: dict[str, Any]
+
+
+@dataclasses.dataclass
+class ExpectedPipelineResource:
+    type: str
+
+
+@dataclasses.dataclass
+class PipelineResult:
+    outputs: list[ExpectedPipelineOutput]
+    resources: list[ExpectedPipelineResource]
+
+
+@dataclasses.dataclass
+class PipelineSelector:
+    """
+    Only support job_definition for now, but we may support other ways to
+    target pipelines in the future.
+    """
+
+    job_definition: str
+
+
+@dataclasses.dataclass
+class PipelineTestSpec:
+    selector: PipelineSelector
+    inventory: list[dict[str, Any]]
+    resources: dict[str, dict[str, str]]
+    pipeline_results: list[PipelineResult]
+
+
+@dataclasses.dataclass
+class PipelineTest(BaseObject):
+    spec: PipelineTestSpec
+
+
+@click.command()
+@click.option(
+    "--topology",
+    type=click.Path(exists=True, dir_okay=True),
+    required=True,
+)
+@click.option(
+    "--tests",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+)
+def main(
+    *,
+    topology: str,
+    tests: str,
+) -> None:
+    # Load the topology
+    if os.path.isdir(topology):
+        static_definitions = load_definitions_from_directory(topology)
+    else:
+        with open(topology, "r", encoding="utf-8") as f:
+            static_definitions = load_definitions_from_str(f.read())
+
+    # Load and execute the tests
+    with open(tests, "r", encoding="utf-8") as f:
+        for loaded_yaml_object in yaml.load_all(f.read(), yaml.SafeLoader):
+            pipeline_test: PipelineTest = fromdict(loaded_yaml_object, PipelineTest)
+            if pipeline_test.kind != "SaturnPipelineTest":
+                raise Exception(f"Unknown object kind {pipeline_test.kind}")
+
+            print(f"Running {pipeline_test.metadata.name}...")
+            run_saturn_pipeline_test(
+                static_definitions=static_definitions,
+                pipeline_test=pipeline_test,
+            )
+
+
+def run_saturn_pipeline_test(
+    *,
+    static_definitions: StaticDefinitions,
+    pipeline_test: PipelineTest,
+) -> None:
+    # Find the pipeline
+    job_definition = static_definitions.job_definitions[
+        pipeline_test.spec.selector.job_definition
+    ]
+    pipeline_info = job_definition.template.pipeline.info
+
+    # Execute it.
+    pipeline_results: list[dict] = []
+
+    for inventory_item in pipeline_test.spec.inventory:
+        pipeline_message = PipelineMessage(
+            info=pipeline_info,
+            message=TopicMessage(args=inventory_item),
+        )
+        pipeline_message.update_with_resources(pipeline_test.spec.resources)
+        pipeline_result = bootstrap_pipeline(pipeline_message)
+        pipeline_results.append(
+            asdict(
+                PipelineResult(
+                    outputs=[
+                        ExpectedPipelineOutput(
+                            channel=output.channel,
+                            args=output.message.args,
+                        )
+                        for output in pipeline_result.outputs
+                    ],
+                    resources=[
+                        ExpectedPipelineResource(
+                            type=resource.type,
+                        )
+                        for resource in pipeline_result.resources
+                    ],
+                )
+            )
+        )
+
+    # Assert the result
+    expected_pipeline_results: list[dict] = [
+        asdict(r) for r in pipeline_test.spec.pipeline_results
+    ]
+    if pipeline_results != expected_pipeline_results:
+        print_diff(
+            expected=expected_pipeline_results,
+            got=pipeline_results,
+        )
+        sys.exit(1)
+    else:
+        print("Success.")
+
+
+def print_diff(*, expected: Any, got: Any) -> None:
+    """
+    Inspired from pyest-icdiff.
+    Licensed under the public domain.
+    """
+    try:
+        import icdiff  # type: ignore
+        from pprintpp import pformat  # type: ignore
+    except ImportError:
+        import pprint
+
+        print("expected:", pprint.pformat(expected))
+        print("got:", pprint.pformat(got))
+        return
+
+    COLS: int = shutil.get_terminal_size().columns
+    MARGIN_L: int = 10
+    GUTTER: int = 2
+    MARGINS: int = MARGIN_L + GUTTER + 1
+
+    half_cols: float = COLS / 2 - MARGINS
+
+    pretty_left = pformat(expected, indent=2, width=half_cols).splitlines()
+    pretty_right = pformat(got, indent=2, width=half_cols).splitlines()
+    diff_cols = COLS - MARGINS
+
+    if len(pretty_left) < 3 or len(pretty_right) < 3:
+        # avoid small diffs far apart by smooshing them up to the left
+        smallest_left = pformat(expected, indent=2, width=1).splitlines()
+        smallest_right = pformat(got, indent=2, width=1).splitlines()
+        max_side = max(len(line) + 1 for line in smallest_left + smallest_right)
+        if (max_side * 2 + MARGINS) < COLS:
+            diff_cols = max_side * 2 + GUTTER
+            pretty_left = pformat(expected, indent=2, width=max_side).splitlines()
+            pretty_right = pformat(got, indent=2, width=max_side).splitlines()
+
+    differ = icdiff.ConsoleDiff(cols=diff_cols, tabsize=2)
+    color_off = icdiff.color_codes["none"]
+
+    icdiff_lines = list(differ.make_table(pretty_left, pretty_right, context=True))
+
+    print("Expected" + (" " * int(half_cols)) + "Got")
+
+    for line in [color_off + line for line in icdiff_lines]:
+        print(line)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
```
    utils: create tester script
    
    Users can now use:
    - `python -m saturn_engine.utils.tester`
    
    This script allows for easily testing saturn objects using
    tests defined in YAML files.
    
    For now, we only support the SaturnPipelineTest kind but we can add
    other test types in the future.
    
    The `simple.yaml` config was also adapted to add an example of an API key
    resource.
    
    You can use `./example/test_pipeline` to see it in action.
```