### PR TITLE
declarative job definition: add default to output

### DIFF
--- a/src/saturn_engine/worker_manager/config/declarative_job_definition.py
+++ b/src/saturn_engine/worker_manager/config/declarative_job_definition.py
@@ -33,8 +33,8 @@ class JobOutput:
 class JobDefinitionTemplate:
     name: str
     input: JobInput
-    output: dict[str, list[JobOutput]]
     pipeline: PipelineInfo
+    output: dict[str, list[JobOutput]] = dataclasses.field(default_factory=dict)
 
     def to_core_object(
         self,

--- a/tests/worker_manager/config/test_declarative.py
+++ b/tests/worker_manager/config/test_declarative.py
@@ -138,3 +138,36 @@ spec:
     assert len(static_definitions.inventories) == 1
     assert len(static_definitions.job_definitions) == 1
     assert len(static_definitions.topics) == 1
+
+
+def test_load_job_definition_without_output() -> None:
+    job_definition_str: str = """
+---
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnJobDefinition
+metadata:
+  name: test-job-definition
+spec:
+  minimalInterval: "@weekly"
+  template:
+    name: test
+
+    input:
+      inventory: test-inventory
+
+    pipeline:
+      name: something.saturn.pipelines.aa.bb
+---
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnInventory
+metadata:
+  name: test-inventory
+spec:
+  type: testtype
+---
+
+"""
+    static_definitions = load_definitions_from_str(job_definition_str)
+
+    assert len(static_definitions.job_definitions) == 1
+    assert len(static_definitions.inventories) == 1


### PR DESCRIPTION
The declaration job definition does not permit omitting the field output, we have to set it to an empty dict. So I propose to give the output a default value to do so.

WDYT? @isra17 @aviau 