### PR TITLE
JoinedInventory: support 'flatten'

### DIFF
--- a/tests/worker/inventories/test_joined_inventory.py
+++ b/tests/worker/inventories/test_joined_inventory.py
@@ -47,3 +47,30 @@ async def test_joined_inventory() -> None:
         ({"a": "1", "b": "2"}, {"a": {"n": 3}, "b": {"c": "C"}}),
     ]
     assert not await alib.list(inventory.iterate(after='{"a": "1", "b": "2"}'))
+
+
+@pytest.mark.asyncio
+async def test_joined_inventory_flatten() -> None:
+    inventory = JoinedInventory.from_options(
+        {
+            "flatten": True,
+            "inventories": [
+                {
+                    "name": "a",
+                    "type": "StaticInventory",
+                    "options": {"items": [{"n": 1}]},
+                },
+                {
+                    "name": "b",
+                    "type": "StaticInventory",
+                    "options": {"items": [{"c": "A"}]},
+                },
+            ],
+            "batch_size": 10,
+        },
+        services=None,
+    )
+    batch = await alib.list(inventory.iterate())
+    assert [(json.loads(i.id), i.args) for i in batch] == [
+        ({"b": "0"}, {"n": 1, "c": "A"})
+    ]


### PR DESCRIPTION
The `JoinedInventory` returns a dict where the key is the sub-inventory name and the values are the sub-inventory arguments.

For example, a JoinedInventory of Fruits and Veggies may return:
```python
{
    "fruits": { "fruit_name": "apple" },
    "veggies": {"veggie_name": "carrot"},
}
```

The pipeline then must access variables like this:
```python
def pipeline(fruits: dict, veggies: dict):
    fruit_name = fruits["fruit_name"]
    veggie = veggies["veggie_name"]
```

In many cases, sub-inventory argument names don't conflict. Wouldn't it be great if the pipeline could just receive the two as separate arguments?

```python
def pipeline(fruit_name: str, veggie_name: str):
    # yay!
```

This is what `flatten` does in a `JoinedInventory`