### PR TITLE
JoinedInventory: support 'alias'

### DIFF
--- a/src/saturn_engine/worker/inventories/joined.py
+++ b/src/saturn_engine/worker/inventories/joined.py
@@ -24,6 +24,7 @@ class JoinedInventory(IteratorInventory):
         inventories: list[InventoryItem]
         batch_size: int = 10
         flatten: bool = False
+        alias: Optional[str] = None
 
     def __init__(self, options: Options, services: Services, **kwargs: object) -> None:
         super().__init__(
@@ -33,6 +34,7 @@ class JoinedInventory(IteratorInventory):
             **kwargs,
         )
         self.flatten: bool = options.flatten
+        self.alias: Optional[str] = options.alias
 
         # This import must be done late since work_factory depends on this module.
         from saturn_engine.worker.work_factory import build_inventory
@@ -54,6 +56,10 @@ class JoinedInventory(IteratorInventory):
                 args = {}
                 for sub_inventory_args in item.args.values():
                     args.update(sub_inventory_args)
+            if self.alias:
+                args = {
+                    self.alias: args,
+                }
             yield Item(id=json.dumps(item.ids), args=args)
 
     async def inventories_iterator(

--- a/tests/worker/inventories/test_joined_inventory.py
+++ b/tests/worker/inventories/test_joined_inventory.py
@@ -74,3 +74,77 @@ async def test_joined_inventory_flatten() -> None:
     assert [(json.loads(i.id), i.args) for i in batch] == [
         ({"b": "0"}, {"n": 1, "c": "A"})
     ]
+
+
+@pytest.mark.asyncio
+async def test_joined_inventory_alias() -> None:
+    # Just alias
+    inventory = JoinedInventory.from_options(
+        {
+            "alias": "veggie_fruit",
+            "inventories": [
+                {
+                    "name": "fruits",
+                    "type": "StaticInventory",
+                    "options": {"items": [{"fruit_name": "apple"}]},
+                },
+                {
+                    "name": "veggies",
+                    "type": "StaticInventory",
+                    "options": {"items": [{"veggie_name": "carrot"}]},
+                },
+            ],
+            "batch_size": 10,
+        },
+        services=None,
+    )
+    batch = await alib.list(inventory.iterate())
+    assert [(json.loads(i.id), i.args) for i in batch] == [
+        (
+            {"veggies": "0"},
+            {
+                "veggie_fruit": {
+                    "veggies": {
+                        "veggie_name": "carrot",
+                    },
+                    "fruits": {
+                        "fruit_name": "apple",
+                    },
+                }
+            },
+        ),
+    ]
+
+    # Alias and flatten
+    inventory = JoinedInventory.from_options(
+        {
+            "alias": "veggie_fruit",
+            "flatten": True,
+            "inventories": [
+                {
+                    "name": "fruits",
+                    "type": "StaticInventory",
+                    "options": {"items": [{"fruit_name": "apple"}]},
+                },
+                {
+                    "name": "veggies",
+                    "type": "StaticInventory",
+                    "options": {"items": [{"veggie_name": "carrot"}]},
+                },
+            ],
+            "batch_size": 10,
+        },
+        services=None,
+    )
+    batch = await alib.list(inventory.iterate())
+    assert [(json.loads(i.id), i.args) for i in batch] == [
+        (
+            {"veggies": "0"},
+            {
+                "veggie_fruit": {
+                    "veggie_name": "carrot",
+                    "fruit_name": "apple",
+                }
+            },
+        ),
+    ]


### PR DESCRIPTION
Allows us to create objects that combine two other inventories.

The  example in my test was to create a `veggie_fruit` that is composed of a `fruit_name` and `veggie_name`.

`alias` is especially useful with `flatten`.

We have a use case for this in our private inventories...