### PR TITLE
refactor config parsing

### DIFF
--- a/example/src/example/pipelines.py
+++ b/example/src/example/pipelines.py
@@ -6,5 +6,5 @@ from .resources import TestApiKey
 
 
 def echo(api_key: TestApiKey, **kwargs: Any) -> TopicMessage:
-    print("api_key: ", api_key.key, "data: ", kwargs)
+    print("api_key:", api_key.key, "data:", kwargs)
     return TopicMessage(args=kwargs)

--- a/src/saturn_engine/utils/declarative_config.py
+++ b/src/saturn_engine/utils/declarative_config.py
@@ -1,0 +1,65 @@
+import dataclasses
+import os
+from typing import Optional
+
+import yaml
+
+
+@dataclasses.dataclass
+class UncompiledObject:
+    api_version: str
+    kind: str
+    data: dict
+
+
+def load_uncompiled_objects_from_str(definitions: str) -> list[UncompiledObject]:
+    uncompiled_objects: list[UncompiledObject] = []
+
+    for yaml_object in yaml.load_all(definitions, yaml.SafeLoader):
+
+        if not yaml_object:
+            continue
+
+        api_version: Optional[str] = yaml_object.get("apiVersion")
+        if not api_version:
+            raise Exception("Missing apiVersion")
+        elif api_version != "saturn.flared.io/v1alpha1":
+            raise Exception(
+                f"apiVersion was {api_version}, "
+                "we only support saturn.flared.io/v1alpha1"
+            )
+
+        object_kind: Optional[str] = yaml_object.get("kind")
+
+        if not object_kind:
+            raise Exception("All objects should have a kind")
+
+        uncompiled_objects.append(
+            UncompiledObject(
+                api_version=api_version,
+                kind=object_kind,
+                data=yaml_object,
+            )
+        )
+
+    return uncompiled_objects
+
+
+def load_uncompiled_objects_from_path(path: str) -> list[UncompiledObject]:
+    if os.path.isdir(path):
+        return load_uncompiled_objects_from_directory(path)
+    with open(path, "r", encoding="utf-8") as f:
+        return load_uncompiled_objects_from_str(f.read())
+
+
+def load_uncompiled_objects_from_directory(config_dir: str) -> list[UncompiledObject]:
+    uncompiled_objects: list[UncompiledObject] = list()
+
+    for config_file in os.listdir(config_dir):
+        if not config_file.endswith(".yaml"):
+            continue
+
+        with open(os.path.join(config_dir, config_file), "r", encoding="utf-8") as f:
+            uncompiled_objects.extend(load_uncompiled_objects_from_str(f.read()))
+
+    return uncompiled_objects

--- a/src/saturn_engine/worker_manager/config/declarative.py
+++ b/src/saturn_engine/worker_manager/config/declarative.py
@@ -1,11 +1,11 @@
-import dataclasses
-import os
 from collections import defaultdict
 from typing import DefaultDict
-from typing import Optional
 
-import yaml
-
+from saturn_engine.utils.declarative_config import UncompiledObject
+from saturn_engine.utils.declarative_config import (
+    load_uncompiled_objects_from_directory,
+)
+from saturn_engine.utils.declarative_config import load_uncompiled_objects_from_str
 from saturn_engine.utils.options import fromdict
 
 from .declarative_inventory import Inventory
@@ -15,47 +15,9 @@ from .declarative_topic_item import TopicItem
 from .static_definitions import StaticDefinitions
 
 
-@dataclasses.dataclass
-class UncompiledObject:
-    api_version: str
-    kind: str
-    data: dict
-
-
-def _load_uncompiled_objects_from_str(definitions: str) -> list[UncompiledObject]:
-    uncompiled_objects: list[UncompiledObject] = []
-
-    for yaml_object in yaml.load_all(definitions, yaml.SafeLoader):
-
-        if not yaml_object:
-            continue
-
-        api_version: Optional[str] = yaml_object.get("apiVersion")
-        if not api_version:
-            raise Exception("Missing apiVersion")
-        elif api_version != "saturn.flared.io/v1alpha1":
-            raise Exception(
-                f"apiVersion was {api_version}, "
-                "we only support saturn.flared.io/v1alpha1"
-            )
-
-        object_kind: Optional[str] = yaml_object.get("kind")
-
-        if not object_kind:
-            raise Exception("All objects should have a kind")
-
-        uncompiled_objects.append(
-            UncompiledObject(
-                api_version=api_version,
-                kind=object_kind,
-                data=yaml_object,
-            )
-        )
-
-    return uncompiled_objects
-
-
-def _compile_objects(uncompiled_objects: list[UncompiledObject]) -> StaticDefinitions:
+def compile_static_definitions(
+    uncompiled_objects: list[UncompiledObject],
+) -> StaticDefinitions:
     objects_by_kind: DefaultDict[str, list[UncompiledObject]] = defaultdict(list)
     for uncompiled_object in uncompiled_objects:
         objects_by_kind[uncompiled_object.kind].append(uncompiled_object)
@@ -91,17 +53,10 @@ def _compile_objects(uncompiled_objects: list[UncompiledObject]) -> StaticDefini
 
 
 def load_definitions_from_str(definitions: str) -> StaticDefinitions:
-    return _compile_objects(_load_uncompiled_objects_from_str(definitions))
+    return compile_static_definitions(load_uncompiled_objects_from_str(definitions))
 
 
 def load_definitions_from_directory(config_dir: str) -> StaticDefinitions:
-    uncompiled_objects: list[UncompiledObject] = list()
-
-    for config_file in os.listdir(config_dir):
-        if not config_file.endswith(".yaml"):
-            continue
-
-        with open(os.path.join(config_dir, config_file), "r", encoding="utf-8") as f:
-            uncompiled_objects.extend(_load_uncompiled_objects_from_str(f.read()))
-
-    return _compile_objects(uncompiled_objects)
+    return compile_static_definitions(
+        load_uncompiled_objects_from_directory(config_dir)
+    )


### PR DESCRIPTION
The worker_manager and the tester had very similar configuration loading code.

I put them in common under `saturn_engine.utils.declarative_config`.

This new package implements loading unknown configuation objects that have a `kind` and an `apiVersion`.

Then, the specific object definitions are impemented in the worker_manager or in the tester.