### PR TITLE
tester: create SaturnInventoryTest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ nox-tests: .venv-tools
 		&& .venv-tools/bin/nox -s tests \
 	"
 
-.PHONY: nox-tests-pipeline
-nox-tests-pipeline: .venv-tools
+.PHONY: nox-example-tests
+nox-example-tests: .venv-tools
 	bash -c "\
 		source .venv-tools/bin/activate \
-		&& .venv-tools/bin/nox -s tests_pipeline \
+		&& .venv-tools/bin/nox -s example_tests \
 	"
 
 .PHONY: nox-mypy

--- a/example/run_tests
+++ b/example/run_tests
@@ -5,4 +5,4 @@ export PYTHONPATH="${PYTHONPATH}:$DIR/src"
 
 python -m saturn_engine.utils.tester.runner \
     --topology=example/definitions/simple.yaml \
-    --tests=example/tests/pipeline_tests.yaml
+    --tests=example/tests

--- a/example/tests/inventory_tests.yaml
+++ b/example/tests/inventory_tests.yaml
@@ -1,0 +1,28 @@
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnInventoryTest
+metadata:
+  name: test-static-inventory-1
+spec:
+  selector:
+    inventory: static-inventory
+  limit: 3
+  items:
+    - id: "0"
+      args: {message: hello-0}
+    - id: "1"
+      args: {message: hello-1}
+    - id: "2"
+      args: {message: hello-2}
+---
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnInventoryTest
+metadata:
+  name: test-static-inventory-resume
+spec:
+  selector:
+    inventory: static-inventory
+  limit: 1
+  after: "2"
+  items:
+    - id: "3"
+      args: {message: hello-3}

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ from typing import Sequence
 import nox
 from nox.sessions import Session
 
-nox.options.sessions = "lint", "mypy", "tests", "tests_pipeline"
+nox.options.sessions = "lint", "mypy", "tests", "example_tests"
 nox.options.reuse_existing_virtualenvs = True
 
 python_all_versions = ["3.9"]
@@ -58,10 +58,10 @@ def tests(session: Session) -> None:
 
 
 @nox.session(python=python_all_versions)
-def tests_pipeline(session: Session) -> None:
+def example_tests(session: Session) -> None:
     args = session.posargs
     install_project(session)
-    session.run("bash", "example/tests_pipeline", *args, external=True)
+    session.run("bash", "example/run_tests", *args, external=True)
 
 
 @nox.session(python=python_all_versions)

--- a/src/saturn_engine/utils/tester/config/inventory_test.py
+++ b/src/saturn_engine/utils/tester/config/inventory_test.py
@@ -1,0 +1,23 @@
+import dataclasses
+from typing import Optional
+
+from saturn_engine.utils.declarative_config import BaseObject
+from saturn_engine.worker.inventories import Item
+
+
+@dataclasses.dataclass
+class InventorySelector:
+    inventory: str
+
+
+@dataclasses.dataclass
+class InventoryTestSpec:
+    selector: InventorySelector
+    items: list[Item]
+    limit: Optional[int] = None
+    after: Optional[str] = None
+
+
+@dataclasses.dataclass
+class InventoryTest(BaseObject):
+    spec: InventoryTestSpec

--- a/src/saturn_engine/utils/tester/diff.py
+++ b/src/saturn_engine/utils/tester/diff.py
@@ -1,0 +1,49 @@
+import shutil
+from typing import Any
+
+
+def print_diff(*, expected: Any, got: Any) -> None:
+    """
+    Inspired from pyest-icdiff.
+    Licensed under the public domain.
+    """
+    try:
+        import icdiff  # type: ignore
+        from pprintpp import pformat  # type: ignore
+    except ImportError:
+        import pprint
+
+        print("expected:", pprint.pformat(expected))
+        print("got:", pprint.pformat(got))
+        return
+
+    COLS: int = shutil.get_terminal_size().columns
+    MARGIN_L: int = 10
+    GUTTER: int = 2
+    MARGINS: int = MARGIN_L + GUTTER + 1
+
+    half_cols: float = COLS / 2 - MARGINS
+
+    pretty_left = pformat(expected, indent=2, width=half_cols).splitlines()
+    pretty_right = pformat(got, indent=2, width=half_cols).splitlines()
+    diff_cols = COLS - MARGINS
+
+    if len(pretty_left) < 3 or len(pretty_right) < 3:
+        # avoid small diffs far apart by smooshing them up to the left
+        smallest_left = pformat(expected, indent=2, width=1).splitlines()
+        smallest_right = pformat(got, indent=2, width=1).splitlines()
+        max_side = max(len(line) + 1 for line in smallest_left + smallest_right)
+        if (max_side * 2 + MARGINS) < COLS:
+            diff_cols = max_side * 2 + GUTTER
+            pretty_left = pformat(expected, indent=2, width=max_side).splitlines()
+            pretty_right = pformat(got, indent=2, width=max_side).splitlines()
+
+    differ = icdiff.ConsoleDiff(cols=diff_cols, tabsize=2)
+    color_off = icdiff.color_codes["none"]
+
+    icdiff_lines = list(differ.make_table(pretty_left, pretty_right, context=True))
+
+    print("Expected" + (" " * int(half_cols)) + "Got")
+
+    for line in [color_off + line for line in icdiff_lines]:
+        print(line)

--- a/src/saturn_engine/utils/tester/inventory_test.py
+++ b/src/saturn_engine/utils/tester/inventory_test.py
@@ -1,0 +1,54 @@
+import asyncio
+
+from saturn_engine.config import default_config_with_env
+from saturn_engine.utils.options import asdict
+from saturn_engine.worker import work_factory
+from saturn_engine.worker.services.manager import ServicesManager
+from saturn_engine.worker_manager.config.static_definitions import StaticDefinitions
+
+from .config.inventory_test import InventoryTest
+from .diff import print_diff
+
+
+def run_saturn_inventory_test(
+    *,
+    static_definitions: StaticDefinitions,
+    inventory_test: InventoryTest,
+) -> None:
+
+    inventory_item = static_definitions.inventories[
+        inventory_test.spec.selector.inventory
+    ]
+
+    inventory = work_factory.build_inventory(
+        inventory_item=inventory_item,
+        services=ServicesManager(
+            config=default_config_with_env(),
+        ).services,
+    )
+
+    items: list[dict] = []
+
+    async def run_inventory() -> None:
+        limit = inventory_test.spec.limit
+        count = 0
+        async for item in inventory.iterate(
+            after=inventory_test.spec.after,
+        ):
+            items.append(asdict(item))
+            count = count + 1
+            if limit and count >= limit:
+                break
+
+    asyncio.run(run_inventory())
+
+    expected_items: list[dict] = [asdict(item) for item in inventory_test.spec.items]
+
+    if items != expected_items:
+        print_diff(
+            expected=expected_items,
+            got=items,
+        )
+        raise AssertionError("Inventory items do not match the expected items")
+    else:
+        print("Success.")

--- a/src/saturn_engine/utils/tester/pipeline_test.py
+++ b/src/saturn_engine/utils/tester/pipeline_test.py
@@ -1,0 +1,66 @@
+from saturn_engine.core import TopicMessage
+from saturn_engine.utils.options import asdict
+from saturn_engine.worker.executors.bootstrap import bootstrap_pipeline
+from saturn_engine.worker.pipeline_message import PipelineMessage
+from saturn_engine.worker_manager.config.static_definitions import StaticDefinitions
+
+from .config.pipeline_test import ExpectedPipelineOutput
+from .config.pipeline_test import ExpectedPipelineResource
+from .config.pipeline_test import PipelineResult
+from .config.pipeline_test import PipelineTest
+from .diff import print_diff
+
+
+def run_saturn_pipeline_test(
+    *,
+    static_definitions: StaticDefinitions,
+    pipeline_test: PipelineTest,
+) -> None:
+    # Find the pipeline
+    job_definition = static_definitions.job_definitions[
+        pipeline_test.spec.selector.job_definition
+    ]
+    pipeline_info = job_definition.template.pipeline.info
+
+    # Execute it.
+    pipeline_results: list[dict] = []
+
+    for inventory_item in pipeline_test.spec.inventory:
+        pipeline_message = PipelineMessage(
+            info=pipeline_info,
+            message=TopicMessage(args=inventory_item),
+        )
+        pipeline_message.update_with_resources(pipeline_test.spec.resources)
+        pipeline_result = bootstrap_pipeline(pipeline_message)
+        pipeline_results.append(
+            asdict(
+                PipelineResult(
+                    outputs=[
+                        ExpectedPipelineOutput(
+                            channel=output.channel,
+                            args=output.message.args,
+                        )
+                        for output in pipeline_result.outputs
+                    ],
+                    resources=[
+                        ExpectedPipelineResource(
+                            type=resource.type,
+                        )
+                        for resource in pipeline_result.resources
+                    ],
+                )
+            )
+        )
+
+    # Assert the result
+    expected_pipeline_results: list[dict] = [
+        asdict(r) for r in pipeline_test.spec.pipeline_results
+    ]
+    if pipeline_results != expected_pipeline_results:
+        print_diff(
+            expected=expected_pipeline_results,
+            got=pipeline_results,
+        )
+        raise AssertionError("Pipeline results do not match the expected output")
+    else:
+        print("Success.")

--- a/src/saturn_engine/utils/tester/runner.py
+++ b/src/saturn_engine/utils/tester/runner.py
@@ -1,31 +1,26 @@
 import dataclasses
-import shutil
 import sys
 from collections import defaultdict
-from typing import Any
 from typing import DefaultDict
 
 import click
 
-from saturn_engine.core import TopicMessage
 from saturn_engine.utils.declarative_config import UncompiledObject
 from saturn_engine.utils.declarative_config import load_uncompiled_objects_from_path
-from saturn_engine.utils.options import asdict
 from saturn_engine.utils.options import fromdict
-from saturn_engine.worker.executors.bootstrap import bootstrap_pipeline
-from saturn_engine.worker.pipeline_message import PipelineMessage
 from saturn_engine.worker_manager.config.declarative import compile_static_definitions
 from saturn_engine.worker_manager.config.static_definitions import StaticDefinitions
 
-from .config.pipeline_test import ExpectedPipelineOutput
-from .config.pipeline_test import ExpectedPipelineResource
-from .config.pipeline_test import PipelineResult
+from .config.inventory_test import InventoryTest
 from .config.pipeline_test import PipelineTest
+from .inventory_test import run_saturn_inventory_test
+from .pipeline_test import run_saturn_pipeline_test
 
 
 @dataclasses.dataclass
 class SaturnTests:
     pipeline_tests: dict[str, PipelineTest] = dataclasses.field(default_factory=dict)
+    inventory_tests: dict[str, InventoryTest] = dataclasses.field(default_factory=dict)
 
 
 def compile_tests(uncompiled_objects: list) -> SaturnTests:
@@ -41,6 +36,12 @@ def compile_tests(uncompiled_objects: list) -> SaturnTests:
             uncompiled_pipeline_test.data, PipelineTest
         )
         tests.pipeline_tests[pipeline_test.metadata.name] = pipeline_test
+
+    for uncompiled_inventory_test in objects_by_kind.pop("SaturnInventoryTest", list()):
+        inventory_test: InventoryTest = fromdict(
+            uncompiled_inventory_test.data, InventoryTest
+        )
+        tests.inventory_tests[inventory_test.metadata.name] = inventory_test
 
     for object_kind in objects_by_kind.keys():
         raise Exception(f"Unsupported kind {object_kind}")
@@ -96,108 +97,11 @@ def run_tests(*, static_definitions: StaticDefinitions, tests: SaturnTests) -> N
             static_definitions=static_definitions,
             pipeline_test=pipeline_test,
         )
-
-
-def run_saturn_pipeline_test(
-    *,
-    static_definitions: StaticDefinitions,
-    pipeline_test: PipelineTest,
-) -> None:
-    # Find the pipeline
-    job_definition = static_definitions.job_definitions[
-        pipeline_test.spec.selector.job_definition
-    ]
-    pipeline_info = job_definition.template.pipeline.info
-
-    # Execute it.
-    pipeline_results: list[dict] = []
-
-    for inventory_item in pipeline_test.spec.inventory:
-        pipeline_message = PipelineMessage(
-            info=pipeline_info,
-            message=TopicMessage(args=inventory_item),
+    for inventory_test in tests.inventory_tests.values():
+        run_saturn_inventory_test(
+            static_definitions=static_definitions,
+            inventory_test=inventory_test,
         )
-        pipeline_message.update_with_resources(pipeline_test.spec.resources)
-        pipeline_result = bootstrap_pipeline(pipeline_message)
-        pipeline_results.append(
-            asdict(
-                PipelineResult(
-                    outputs=[
-                        ExpectedPipelineOutput(
-                            channel=output.channel,
-                            args=output.message.args,
-                        )
-                        for output in pipeline_result.outputs
-                    ],
-                    resources=[
-                        ExpectedPipelineResource(
-                            type=resource.type,
-                        )
-                        for resource in pipeline_result.resources
-                    ],
-                )
-            )
-        )
-
-    # Assert the result
-    expected_pipeline_results: list[dict] = [
-        asdict(r) for r in pipeline_test.spec.pipeline_results
-    ]
-    if pipeline_results != expected_pipeline_results:
-        print_diff(
-            expected=expected_pipeline_results,
-            got=pipeline_results,
-        )
-        raise AssertionError("Pipeline results do not match the expected output")
-    else:
-        print("Success.")
-
-
-def print_diff(*, expected: Any, got: Any) -> None:
-    """
-    Inspired from pyest-icdiff.
-    Licensed under the public domain.
-    """
-    try:
-        import icdiff  # type: ignore
-        from pprintpp import pformat  # type: ignore
-    except ImportError:
-        import pprint
-
-        print("expected:", pprint.pformat(expected))
-        print("got:", pprint.pformat(got))
-        return
-
-    COLS: int = shutil.get_terminal_size().columns
-    MARGIN_L: int = 10
-    GUTTER: int = 2
-    MARGINS: int = MARGIN_L + GUTTER + 1
-
-    half_cols: float = COLS / 2 - MARGINS
-
-    pretty_left = pformat(expected, indent=2, width=half_cols).splitlines()
-    pretty_right = pformat(got, indent=2, width=half_cols).splitlines()
-    diff_cols = COLS - MARGINS
-
-    if len(pretty_left) < 3 or len(pretty_right) < 3:
-        # avoid small diffs far apart by smooshing them up to the left
-        smallest_left = pformat(expected, indent=2, width=1).splitlines()
-        smallest_right = pformat(got, indent=2, width=1).splitlines()
-        max_side = max(len(line) + 1 for line in smallest_left + smallest_right)
-        if (max_side * 2 + MARGINS) < COLS:
-            diff_cols = max_side * 2 + GUTTER
-            pretty_left = pformat(expected, indent=2, width=max_side).splitlines()
-            pretty_right = pformat(got, indent=2, width=max_side).splitlines()
-
-    differ = icdiff.ConsoleDiff(cols=diff_cols, tabsize=2)
-    color_off = icdiff.color_codes["none"]
-
-    icdiff_lines = list(differ.make_table(pretty_left, pretty_right, context=True))
-
-    print("Expected" + (" " * int(half_cols)) + "Got")
-
-    for line in [color_off + line for line in icdiff_lines]:
-        print(line)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Allows for easily running inventories and verifying if they yield the expected results.

I would have liked to have this to develop some of our private inventories.

Also refactored the tester to split it into several files.
- `tester/runner.py`
- `tester/config/pipeline_test.py`
- `tester/config/inventory_test.py`
- `tester/pipeline_test.py`
- `tester/inventory_test.py`


A `SaturnInventoryTest` looks like this:
```yaml
apiVersion: saturn.flared.io/v1alpha1
kind: SaturnInventoryTest
metadata:
  name: test-static-inventory-resume
spec:
  selector:
    inventory: static-inventory
  limit: 1
  after: "2"
  items:
    - id: "3"
      args: {message: hello-3}
```