### PR TITLE
tester: better error handling

### DIFF
--- a/src/saturn_engine/utils/tester/diff.py
+++ b/src/saturn_engine/utils/tester/diff.py
@@ -2,9 +2,9 @@ import shutil
 from typing import Any
 
 
-def print_diff(*, expected: Any, got: Any) -> None:
+def get_diff(*, expected: Any, got: Any) -> str:
     """
-    Inspired from pyest-icdiff.
+    Inspired from pytest-icdiff.
     Licensed under the public domain.
     """
     try:
@@ -13,9 +13,7 @@ def print_diff(*, expected: Any, got: Any) -> None:
     except ImportError:
         import pprint
 
-        print("expected:", pprint.pformat(expected))
-        print("got:", pprint.pformat(got))
-        return
+        return f"expected: {pprint.pformat(expected)}\ngot: {pprint.pformat(got)}"
 
     COLS: int = shutil.get_terminal_size().columns
     MARGIN_L: int = 10
@@ -41,9 +39,11 @@ def print_diff(*, expected: Any, got: Any) -> None:
     differ = icdiff.ConsoleDiff(cols=diff_cols, tabsize=2)
     color_off = icdiff.color_codes["none"]
 
-    icdiff_lines = list(differ.make_table(pretty_left, pretty_right, context=True))
+    header: str = "Expected" + (" " * int(half_cols)) + "Got"
 
-    print("Expected" + (" " * int(half_cols)) + "Got")
+    icdiff_lines: list[str] = [header]
+    icdiff_lines.extend(
+        list(differ.make_table(pretty_left, pretty_right, context=True))
+    )
 
-    for line in [color_off + line for line in icdiff_lines]:
-        print(line)
+    return "\n".join([color_off + line for line in icdiff_lines])

--- a/src/saturn_engine/utils/tester/inventory_test.py
+++ b/src/saturn_engine/utils/tester/inventory_test.py
@@ -7,7 +7,7 @@ from saturn_engine.worker.services.manager import ServicesManager
 from saturn_engine.worker_manager.config.static_definitions import StaticDefinitions
 
 from .config.inventory_test import InventoryTest
-from .diff import print_diff
+from .diff import get_diff
 
 
 def run_saturn_inventory_test(
@@ -45,10 +45,10 @@ def run_saturn_inventory_test(
     expected_items: list[dict] = [asdict(item) for item in inventory_test.spec.items]
 
     if items != expected_items:
-        print_diff(
+        diff: str = get_diff(
             expected=expected_items,
             got=items,
         )
-        raise AssertionError("Inventory items do not match the expected items")
-    else:
-        print("Success.")
+        raise AssertionError(
+            f"Inventory items do not match the expected items:\n{diff}"
+        )

--- a/src/saturn_engine/utils/tester/pipeline_test.py
+++ b/src/saturn_engine/utils/tester/pipeline_test.py
@@ -8,7 +8,7 @@ from .config.pipeline_test import ExpectedPipelineOutput
 from .config.pipeline_test import ExpectedPipelineResource
 from .config.pipeline_test import PipelineResult
 from .config.pipeline_test import PipelineTest
-from .diff import print_diff
+from .diff import get_diff
 
 
 def run_saturn_pipeline_test(
@@ -57,10 +57,10 @@ def run_saturn_pipeline_test(
         asdict(r) for r in pipeline_test.spec.pipeline_results
     ]
     if pipeline_results != expected_pipeline_results:
-        print_diff(
+        diff: str = get_diff(
             expected=expected_pipeline_results,
             got=pipeline_results,
         )
-        raise AssertionError("Pipeline results do not match the expected output")
-    else:
-        print("Success.")
+        raise AssertionError(
+            f"Pipeline results do not match the expected output:\n{diff}"
+        )

--- a/src/saturn_engine/utils/tester/runner.py
+++ b/src/saturn_engine/utils/tester/runner.py
@@ -70,7 +70,8 @@ def main(
             static_definitions=topology,
             tests=tests,
         )
-    except AssertionError:
+    except AssertionError as e:
+        print(e)
         sys.exit(1)
 
 
@@ -93,11 +94,13 @@ def run_tests_from_files(
 
 def run_tests(*, static_definitions: StaticDefinitions, tests: SaturnTests) -> None:
     for pipeline_test in tests.pipeline_tests.values():
+        print(f"Running {pipeline_test.metadata.name}...")
         run_saturn_pipeline_test(
             static_definitions=static_definitions,
             pipeline_test=pipeline_test,
         )
     for inventory_test in tests.inventory_tests.values():
+        print(f"Running {inventory_test.metadata.name}...")
         run_saturn_inventory_test(
             static_definitions=static_definitions,
             inventory_test=inventory_test,


### PR DESCRIPTION
I made it so that the tests themselves don't print anything anymore.

Instead, we raise an exception that contains the diff.

Then, whoever ran the test can decide to catch the exception and print it.