### PR TITLE
isort: configure import sections

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -3,9 +3,10 @@ Nox is used to run all testing and linting tools in differents environments.
 To run locally, simply `pip install --user --upgrade nox` and then run `nox`
 """
 
-import tempfile
 from typing import Any
 from typing import Sequence
+
+import tempfile
 
 import nox
 from nox.sessions import Session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,18 @@ filterwarnings = [
 [tool.isort]
 profile = "black"
 force_single_line = true
+known_typing_library = '''
+    typing,
+    typing_extensions,
+'''
+sections = '''
+    FUTURE,
+    TYPING_LIBRARY,
+    STDLIB,
+    THIRDPARTY,
+    FIRSTPARTY,
+    LOCALFOLDER
+'''
 
 [build-system]
 requires = ["poetry_core>=1.0.0", "setuptools"]

--- a/src/saturn_engine/client/worker_manager.py
+++ b/src/saturn_engine/client/worker_manager.py
@@ -1,5 +1,6 @@
-import socket
 from typing import Optional
+
+import socket
 
 import aiohttp
 

--- a/src/saturn_engine/core/api.py
+++ b/src/saturn_engine/core/api.py
@@ -1,10 +1,11 @@
-import dataclasses
-from datetime import datetime
 from typing import Any
 from typing import Generic
 from typing import Optional
 from typing import TypeVar
 from typing import Union
+
+import dataclasses
+from datetime import datetime
 
 from saturn_engine.core import PipelineInfo  # noqa: F401  # Reexport for public API
 from saturn_engine.core import QueuePipeline

--- a/src/saturn_engine/core/pipeline.py
+++ b/src/saturn_engine/core/pipeline.py
@@ -1,8 +1,9 @@
-import dataclasses
-import inspect
 from typing import Any
 from typing import Callable
 from typing import cast
+
+import dataclasses
+import inspect
 
 from saturn_engine.utils import inspect as extra_inspect
 from saturn_engine.utils.options import schema_for

--- a/src/saturn_engine/core/resource.py
+++ b/src/saturn_engine/core/resource.py
@@ -1,6 +1,7 @@
-import dataclasses
 from typing import ClassVar
 from typing import Optional
+
+import dataclasses
 
 
 @dataclasses.dataclass(eq=False)

--- a/src/saturn_engine/database.py
+++ b/src/saturn_engine/database.py
@@ -1,9 +1,10 @@
-from contextlib import contextmanager
 from typing import Any
 from typing import Callable
 from typing import Iterator
 from typing import Optional
 from typing import Union
+
+from contextlib import contextmanager
 
 import sqlalchemy.orm
 from sqlalchemy.engine import Engine

--- a/src/saturn_engine/models/job.py
+++ b/src/saturn_engine/models/job.py
@@ -1,5 +1,6 @@
-from datetime import datetime
 from typing import Optional
+
+from datetime import datetime
 
 from sqlalchemy import Column
 from sqlalchemy import ForeignKey

--- a/src/saturn_engine/models/queue.py
+++ b/src/saturn_engine/models/queue.py
@@ -1,5 +1,6 @@
-import dataclasses
 from typing import Optional
+
+import dataclasses
 
 from sqlalchemy import Column
 from sqlalchemy import Text

--- a/src/saturn_engine/models/types.py
+++ b/src/saturn_engine/models/types.py
@@ -1,9 +1,10 @@
-import json
 import typing
-from datetime import datetime
-from datetime import timezone
 from typing import Any
 from typing import Optional
+
+import json
+from datetime import datetime
+from datetime import timezone
 
 from sqlalchemy import types
 from sqlalchemy.engine.interfaces import Dialect

--- a/src/saturn_engine/stores/jobs_store.py
+++ b/src/saturn_engine/stores/jobs_store.py
@@ -1,5 +1,6 @@
-from datetime import datetime
 from typing import Optional
+
+from datetime import datetime
 
 from sqlalchemy import select
 from sqlalchemy import update

--- a/src/saturn_engine/utils/__init__.py
+++ b/src/saturn_engine/utils/__init__.py
@@ -1,3 +1,9 @@
+from typing import Any
+from typing import Callable
+from typing import Generic
+from typing import TypeVar
+from typing import Union
+
 import collections
 import enum
 import threading
@@ -6,11 +12,6 @@ from collections.abc import Iterator
 from datetime import datetime
 from datetime import timezone
 from functools import wraps
-from typing import Any
-from typing import Callable
-from typing import Generic
-from typing import TypeVar
-from typing import Union
 
 T = TypeVar("T")
 

--- a/src/saturn_engine/utils/asyncutils.py
+++ b/src/saturn_engine/utils/asyncutils.py
@@ -1,14 +1,15 @@
+from typing import Any
+from typing import Callable
+from typing import Generic
+from typing import Optional
+from typing import TypeVar
+
 import asyncio
 import contextlib
 from collections.abc import AsyncGenerator
 from collections.abc import AsyncIterator
 from collections.abc import Awaitable
 from collections.abc import Iterable
-from typing import Any
-from typing import Callable
-from typing import Generic
-from typing import Optional
-from typing import TypeVar
 
 from saturn_engine.utils.log import getLogger
 

--- a/src/saturn_engine/utils/config.py
+++ b/src/saturn_engine/utils/config.py
@@ -1,15 +1,16 @@
-import inspect
-import os
 import typing
-from collections.abc import Iterable
-from collections.abc import Mapping
-from enum import Enum
-from types import GenericAlias
 from typing import Any
 from typing import Generic
 from typing import Type
 from typing import TypeVar
 from typing import cast
+
+import inspect
+import os
+from collections.abc import Iterable
+from collections.abc import Mapping
+from enum import Enum
+from types import GenericAlias
 
 from . import CINamespace
 from .inspect import eval_class_annotations

--- a/src/saturn_engine/utils/declarative_config.py
+++ b/src/saturn_engine/utils/declarative_config.py
@@ -1,6 +1,7 @@
+from typing import Optional
+
 import dataclasses
 import os
-from typing import Optional
 
 import yaml
 

--- a/src/saturn_engine/utils/inspect.py
+++ b/src/saturn_engine/utils/inspect.py
@@ -1,11 +1,12 @@
-import functools
-import inspect
-import sys
-from collections.abc import Iterable
 from typing import Any
 from typing import Callable
 from typing import Type
 from typing import Union
+
+import functools
+import inspect
+import sys
+from collections.abc import Iterable
 
 
 def eval_annotations(func: Callable, signature: inspect.Signature) -> inspect.Signature:

--- a/src/saturn_engine/utils/log.py
+++ b/src/saturn_engine/utils/log.py
@@ -1,7 +1,8 @@
-import logging
 from typing import Type
 from typing import TypeVar
 from typing import Union
+
+import logging
 
 T = TypeVar("T")
 

--- a/src/saturn_engine/utils/options.py
+++ b/src/saturn_engine/utils/options.py
@@ -1,14 +1,15 @@
+from typing import Any
+from typing import Optional
+from typing import Type
+from typing import TypeVar
+from typing import cast
+
 import dataclasses
 import functools
 from abc import abstractmethod
 from collections.abc import Hashable
 from collections.abc import Mapping
 from functools import cache
-from typing import Any
-from typing import Optional
-from typing import Type
-from typing import TypeVar
-from typing import cast
 
 import desert
 import marshmallow

--- a/src/saturn_engine/utils/tester/config/inventory_test.py
+++ b/src/saturn_engine/utils/tester/config/inventory_test.py
@@ -1,5 +1,6 @@
-import dataclasses
 from typing import Optional
+
+import dataclasses
 
 from saturn_engine.utils.declarative_config import BaseObject
 from saturn_engine.worker.inventories import Item

--- a/src/saturn_engine/utils/tester/config/pipeline_test.py
+++ b/src/saturn_engine/utils/tester/config/pipeline_test.py
@@ -1,5 +1,6 @@
-import dataclasses
 from typing import Any
+
+import dataclasses
 
 from saturn_engine.utils.declarative_config import BaseObject
 

--- a/src/saturn_engine/utils/tester/diff.py
+++ b/src/saturn_engine/utils/tester/diff.py
@@ -1,5 +1,6 @@
-import shutil
 from typing import Any
+
+import shutil
 
 
 def get_diff(*, expected: Any, got: Any) -> str:

--- a/src/saturn_engine/utils/tester/runner.py
+++ b/src/saturn_engine/utils/tester/runner.py
@@ -1,7 +1,8 @@
+from typing import DefaultDict
+
 import dataclasses
 import sys
 from collections import defaultdict
-from typing import DefaultDict
 
 import click
 

--- a/src/saturn_engine/worker/broker.py
+++ b/src/saturn_engine/worker/broker.py
@@ -1,7 +1,8 @@
-import asyncio
 from typing import Callable
 from typing import Optional
 from typing import Protocol
+
+import asyncio
 
 from saturn_engine.config import Config
 from saturn_engine.utils.log import getLogger

--- a/src/saturn_engine/worker/executable_message.py
+++ b/src/saturn_engine/worker/executable_message.py
@@ -1,6 +1,7 @@
-import contextlib
 from typing import AsyncContextManager
 from typing import Optional
+
+import contextlib
 
 from saturn_engine.core import ResourceUsed
 from saturn_engine.worker.parkers import Parkers

--- a/src/saturn_engine/worker/executors/__init__.py
+++ b/src/saturn_engine/worker/executors/__init__.py
@@ -1,6 +1,7 @@
+from typing import Type
+
 import asyncio
 from abc import abstractmethod
-from typing import Type
 
 from saturn_engine.core import PipelineOutput
 from saturn_engine.core import PipelineResult

--- a/src/saturn_engine/worker/inventories/__init__.py
+++ b/src/saturn_engine/worker/inventories/__init__.py
@@ -1,10 +1,11 @@
+from typing import Any
+from typing import Optional
+from typing import Type
+
 import abc
 import asyncio
 import dataclasses
 from collections.abc import AsyncIterator
-from typing import Any
-from typing import Optional
-from typing import Type
 
 import asyncstdlib as alib
 

--- a/src/saturn_engine/worker/inventories/dummy.py
+++ b/src/saturn_engine/worker/inventories/dummy.py
@@ -1,5 +1,6 @@
-import dataclasses
 from typing import Optional
+
+import dataclasses
 
 from . import Inventory
 from . import Item

--- a/src/saturn_engine/worker/inventories/joined.py
+++ b/src/saturn_engine/worker/inventories/joined.py
@@ -1,9 +1,10 @@
-import dataclasses
-import json
-from collections.abc import AsyncIterator
 from typing import Any
 from typing import NamedTuple
 from typing import Optional
+
+import dataclasses
+import json
+from collections.abc import AsyncIterator
 
 from saturn_engine.core.api import InventoryItem
 from saturn_engine.worker.services import Services

--- a/src/saturn_engine/worker/inventories/static.py
+++ b/src/saturn_engine/worker/inventories/static.py
@@ -1,6 +1,7 @@
-import dataclasses
 from typing import Any
 from typing import Optional
+
+import dataclasses
 
 from . import Inventory
 from . import Item

--- a/src/saturn_engine/worker/job/__init__.py
+++ b/src/saturn_engine/worker/job/__init__.py
@@ -1,5 +1,6 @@
-import abc
 from typing import Optional
+
+import abc
 
 import asyncstdlib as alib
 

--- a/src/saturn_engine/worker/queue.py
+++ b/src/saturn_engine/worker/queue.py
@@ -1,5 +1,6 @@
-from collections.abc import AsyncGenerator
 from typing import AsyncContextManager
+
+from collections.abc import AsyncGenerator
 
 from saturn_engine.core import QueuePipeline
 

--- a/src/saturn_engine/worker/resources_manager.py
+++ b/src/saturn_engine/worker/resources_manager.py
@@ -1,10 +1,11 @@
+from typing import Optional
+
 import asyncio
 import contextlib
 import dataclasses
 import time
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import Optional
 
 
 @dataclasses.dataclass(eq=False)

--- a/src/saturn_engine/worker/scheduler.py
+++ b/src/saturn_engine/worker/scheduler.py
@@ -1,10 +1,11 @@
+from typing import Generic
+from typing import TypeVar
+
 import asyncio
 import contextlib
 import dataclasses
 from collections.abc import AsyncGenerator
 from collections.abc import AsyncIterator
-from typing import Generic
-from typing import TypeVar
 
 from saturn_engine.utils.asyncutils import TasksGroup
 from saturn_engine.utils.log import getLogger

--- a/src/saturn_engine/worker/task_manager.py
+++ b/src/saturn_engine/worker/task_manager.py
@@ -1,6 +1,7 @@
+from typing import Union
+
 import asyncio
 from collections.abc import Coroutine
-from typing import Union
 
 from saturn_engine.utils.asyncutils import TasksGroup
 from saturn_engine.utils.log import getLogger

--- a/src/saturn_engine/worker/topics/__init__.py
+++ b/src/saturn_engine/worker/topics/__init__.py
@@ -1,10 +1,11 @@
-import abc
-import asyncio
-from collections.abc import AsyncGenerator
 from typing import AsyncContextManager
 from typing import Optional
 from typing import Type
 from typing import Union
+
+import abc
+import asyncio
+from collections.abc import AsyncGenerator
 
 from saturn_engine.core import TopicMessage
 from saturn_engine.utils.options import OptionsSchema

--- a/src/saturn_engine/worker/topics/file.py
+++ b/src/saturn_engine/worker/topics/file.py
@@ -1,9 +1,10 @@
+from typing import TextIO
+from typing import cast
+
 import dataclasses
 import json
 import sys
 from collections.abc import AsyncGenerator
-from typing import TextIO
-from typing import cast
 
 from saturn_engine.core import TopicMessage
 

--- a/src/saturn_engine/worker/topics/memory.py
+++ b/src/saturn_engine/worker/topics/memory.py
@@ -1,10 +1,11 @@
+from typing import Any
+from typing import AsyncContextManager
+
 import asyncio
 import dataclasses
 from collections.abc import AsyncGenerator
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any
-from typing import AsyncContextManager
 
 from saturn_engine.core import TopicMessage
 

--- a/src/saturn_engine/worker/work.py
+++ b/src/saturn_engine/worker/work.py
@@ -1,5 +1,6 @@
-import dataclasses
 from typing import Type
+
+import dataclasses
 
 from .queue import ExecutableQueue
 from .scheduler import Schedulable

--- a/src/saturn_engine/worker/work_factory.py
+++ b/src/saturn_engine/worker/work_factory.py
@@ -1,5 +1,6 @@
-import asyncio
 from typing import Optional
+
+import asyncio
 
 from saturn_engine.core.api import InventoryItem
 from saturn_engine.core.api import QueueItem

--- a/src/saturn_engine/worker/work_manager.py
+++ b/src/saturn_engine/worker/work_manager.py
@@ -1,13 +1,14 @@
-import asyncio
-import dataclasses
-from collections.abc import Iterable
-from datetime import datetime
-from datetime import timedelta
 from typing import Generic
 from typing import Iterator
 from typing import Optional
 from typing import Type
 from typing import TypeVar
+
+import asyncio
+import dataclasses
+from collections.abc import Iterable
+from datetime import datetime
+from datetime import timedelta
 
 from saturn_engine.client.worker_manager import WorkerManagerClient
 from saturn_engine.core.api import LockResponse

--- a/src/saturn_engine/worker_manager/config/declarative.py
+++ b/src/saturn_engine/worker_manager/config/declarative.py
@@ -1,5 +1,6 @@
-from collections import defaultdict
 from typing import DefaultDict
+
+from collections import defaultdict
 
 from saturn_engine.utils.declarative_config import UncompiledObject
 from saturn_engine.utils.declarative_config import (

--- a/src/saturn_engine/worker_manager/config/declarative_inventory.py
+++ b/src/saturn_engine/worker_manager/config/declarative_inventory.py
@@ -1,5 +1,6 @@
-import dataclasses
 from typing import Any
+
+import dataclasses
 
 from saturn_engine.core import api
 from saturn_engine.utils.declarative_config import BaseObject

--- a/src/saturn_engine/worker_manager/config/declarative_pipeline.py
+++ b/src/saturn_engine/worker_manager/config/declarative_pipeline.py
@@ -1,5 +1,6 @@
-import dataclasses
 from typing import Any
+
+import dataclasses
 
 from saturn_engine.core import api
 

--- a/src/saturn_engine/worker_manager/config/declarative_resource.py
+++ b/src/saturn_engine/worker_manager/config/declarative_resource.py
@@ -1,5 +1,6 @@
-import dataclasses
 from typing import Any
+
+import dataclasses
 
 from saturn_engine.core import api
 from saturn_engine.utils.declarative_config import BaseObject

--- a/src/saturn_engine/worker_manager/config/declarative_topic_item.py
+++ b/src/saturn_engine/worker_manager/config/declarative_topic_item.py
@@ -1,5 +1,6 @@
-import dataclasses
 from typing import Any
+
+import dataclasses
 
 from saturn_engine.core import api
 from saturn_engine.utils.declarative_config import BaseObject

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
-import asyncio
-from collections.abc import Iterator
 from typing import Callable
 from typing import Union
+
+import asyncio
+from collections.abc import Iterator
 
 import freezegun
 import pytest

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,5 +1,6 @@
-import dataclasses
 from typing import Union
+
+import dataclasses
 
 from saturn_engine.utils.options import ObjectUnion
 from saturn_engine.utils.options import asdict

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
-import asyncio
 from typing import Any
+
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,12 +1,13 @@
+from typing import Any
+from typing import Callable
+from typing import Optional
+from typing import cast
+
 import asyncio
 import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from selectors import DefaultSelector
-from typing import Any
-from typing import Callable
-from typing import Optional
-from typing import cast
 from unittest import mock
 from unittest.mock import Mock
 

--- a/tests/worker/conftest.py
+++ b/tests/worker/conftest.py
@@ -1,9 +1,10 @@
+from typing import Callable
+from typing import Optional
+
 import contextlib
 import dataclasses
 from collections.abc import AsyncIterator
 from collections.abc import Iterator
-from typing import Callable
-from typing import Optional
 from unittest.mock import Mock
 from unittest.mock import create_autospec
 

--- a/tests/worker/test_broker.py
+++ b/tests/worker/test_broker.py
@@ -1,5 +1,6 @@
-import asyncio
 from typing import Callable
+
+import asyncio
 from unittest.mock import Mock
 
 import pytest

--- a/tests/worker/test_executor.py
+++ b/tests/worker/test_executor.py
@@ -1,6 +1,7 @@
+from typing import Callable
+
 import asyncio
 from functools import partial
-from typing import Callable
 
 import pytest
 

--- a/tests/worker/test_pipeline_info.py
+++ b/tests/worker/test_pipeline_info.py
@@ -1,5 +1,6 @@
-from functools import wraps
 from typing import Callable
+
+from functools import wraps
 
 import pytest
 

--- a/tests/worker/test_services_manager.py
+++ b/tests/worker/test_services_manager.py
@@ -1,5 +1,6 @@
-import dataclasses
 from typing import Optional
+
+import dataclasses
 
 import pytest
 

--- a/tests/worker/topics/test_blocking_topic.py
+++ b/tests/worker/topics/test_blocking_topic.py
@@ -1,6 +1,7 @@
+from typing import Optional
+
 import asyncio
 import threading
-from typing import Optional
 
 import asyncstdlib as alib
 import pytest

--- a/tests/worker_manager/api/test_lock.py
+++ b/tests/worker_manager/api/test_lock.py
@@ -1,6 +1,7 @@
+from typing import Callable
+
 from datetime import datetime
 from datetime import timedelta
-from typing import Callable
 
 import werkzeug.test
 from flask.testing import FlaskClient


### PR DESCRIPTION
typing imports are spammy so let's isolate them to one block.

(I took the config from you-know-what)