### PR TITLE
worker(loggers): Add extensions to log message to console

### DIFF
--- a/src/saturn_engine/default_config.py
+++ b/src/saturn_engine/default_config.py
@@ -18,6 +18,8 @@ class config(SaturnConfig):
             "SATURN_WORKER_MANAGER_URL", "http://localhost:5000"
         )
         services = [
+            "saturn_engine.worker.services.loggers.ConsoleLogging",
+            "saturn_engine.worker.services.loggers.MessagesLogger",
             "saturn_engine.worker.services.metrics.MemoryMetrics",
             "saturn_engine.worker.services.rabbitmq.RabbitMQService",
         ]

--- a/src/saturn_engine/utils/serializer.py
+++ b/src/saturn_engine/utils/serializer.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+import shutil
+from pprint import pformat
+
+from . import lazy
+
+
+@lazy()
+def terminal_size() -> tuple[int, int]:
+    return shutil.get_terminal_size()
+
+
+def human_encode(data: Any, compact: bool = False) -> str:
+    width, _ = terminal_size()
+    return pformat(data, compact=compact, width=width)

--- a/src/saturn_engine/worker/services/loggers/__init__.py
+++ b/src/saturn_engine/worker/services/loggers/__init__.py
@@ -1,0 +1,4 @@
+from .console_logging import ConsoleLogging
+from .messages_logger import MessagesLogger
+
+__all__ = ("ConsoleLogging", "MessagesLogger")

--- a/src/saturn_engine/worker/services/loggers/console_logging.py
+++ b/src/saturn_engine/worker/services/loggers/console_logging.py
@@ -1,0 +1,85 @@
+import logging
+import logging.config
+
+from saturn_engine.utils.serializer import human_encode
+
+from .. import MinimalService
+
+
+class ConsoleLogging(MinimalService):
+    name = "console_logging"
+
+    async def open(self) -> None:
+        # if not setup_structlog():
+        setup_logging()
+
+
+# def setup_structlog() -> bool:
+#     try:
+#         import structlog
+#     except ImportError:
+#         logging.warning(
+#             "Console logging setup without structlog. For a more pleasant and "
+#             "colorful experience, install saturn with console (pip install "
+#             "saturn-engine[console])"
+#         )
+#         return False
+
+
+class ExtraFormatter(logging.Formatter):
+    def_keys = [
+        "name",
+        "msg",
+        "args",
+        "levelname",
+        "levelno",
+        "pathname",
+        "filename",
+        "module",
+        "exc_info",
+        "exc_text",
+        "stack_info",
+        "lineno",
+        "funcName",
+        "created",
+        "msecs",
+        "relativeCreated",
+        "thread",
+        "threadName",
+        "processName",
+        "process",
+        "message",
+        "asctime",
+    ]
+
+    def format(self, record: logging.LogRecord) -> str:
+        string = super().format(record)
+        extra = {k: v for k, v in record.__dict__.items() if k not in self.def_keys}
+        extra.update(extra.pop("data", {}))
+        if extra:
+            string += " - " + human_encode(extra, compact=True)
+        return string
+
+
+def setup_logging() -> None:
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": True,
+            "formatters": {
+                "standard": {
+                    "class": __name__ + "." + ExtraFormatter.__name__,
+                    "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+                },
+            },
+            "handlers": {
+                "default": {
+                    "level": "DEBUG",
+                    "formatter": "standard",
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",  # Default is stderr
+                },
+            },
+            "root": {"handlers": ["default"], "level": "DEBUG"},
+        }
+    )

--- a/src/saturn_engine/worker/services/loggers/messages_logger.py
+++ b/src/saturn_engine/worker/services/loggers/messages_logger.py
@@ -1,0 +1,105 @@
+from typing import Any
+
+import logging
+from collections.abc import AsyncGenerator
+
+from saturn_engine.core import PipelineOutput
+from saturn_engine.core import PipelineResult
+from saturn_engine.core import TopicMessage
+from saturn_engine.worker.pipeline_message import PipelineMessage
+from saturn_engine.worker.services.hooks import MessagePublished
+
+from .. import BaseServices
+from .. import Service
+
+
+class MessagesLogger(Service[BaseServices, "MessagesLogger.Options"]):
+    name = "message_logger"
+
+    class Options:
+        verbose: bool = False
+
+    async def open(self) -> None:
+        self.logger = logging.getLogger("saturn.messages")
+
+        self.services.hooks.message_polled.register(self.on_message_polled)
+        self.services.hooks.message_scheduled.register(self.on_message_scheduled)
+        self.services.hooks.message_submitted.register(self.on_message_submitted)
+        self.services.hooks.message_executed.register(self.on_message_executed)
+        self.services.hooks.message_published.register(self.on_message_published)
+
+    async def on_message_polled(self, message: PipelineMessage) -> None:
+        self.logger.debug("Polled message", extra={"data": self.message_data(message)})
+
+    async def on_message_scheduled(self, message: PipelineMessage) -> None:
+        self.logger.debug(
+            "Scheduled message", extra={"data": self.message_data(message)}
+        )
+
+    async def on_message_submitted(self, message: PipelineMessage) -> None:
+        self.logger.debug(
+            "Submitted message", extra={"data": self.message_data(message)}
+        )
+
+    async def on_message_executed(
+        self, message: PipelineMessage
+    ) -> AsyncGenerator[None, PipelineResult]:
+        self.logger.debug(
+            "Executing message", extra={"data": self.message_data(message)}
+        )
+        try:
+            result = yield
+            self.logger.debug(
+                "Executed message",
+                extra={
+                    "data": self.message_data(message)
+                    | {
+                        "result": self.result_data(result),
+                    }
+                },
+            )
+        except Exception:
+            self.logger.exception(
+                "Failed to execute message", extra={"data": self.message_data(message)}
+            )
+
+    async def on_message_published(
+        self, event: MessagePublished
+    ) -> AsyncGenerator[None, None]:
+        self.logger.debug(
+            "Publishing message", extra={"data": self.published_data(event)}
+        )
+        try:
+            yield
+            self.logger.debug(
+                "Published message", extra={"data": self.published_data(event)}
+            )
+        except Exception:
+            self.logger.exception(
+                "Failed to publish message", extra={"data": self.published_data(event)}
+            )
+
+    def message_data(self, message: PipelineMessage) -> dict[str, Any]:
+        return {
+            "message": self.topic_message_data(message.message),
+            "pipeline": message.info.name,
+        }
+
+    def published_data(self, event: MessagePublished) -> dict[str, Any]:
+        return {"from": self.message_data(event.message)} | self.output_data(
+            event.output
+        )
+
+    def topic_message_data(self, message: TopicMessage) -> dict[str, Any]:
+        return {
+            "id": message.id,
+        } | ({"args": message.args} if self.options.verbose else {})
+
+    def result_data(self, results: PipelineResult) -> list[dict[str, Any]]:
+        return [self.output_data(o) for o in results.outputs]
+
+    def output_data(self, output: PipelineOutput) -> dict[str, Any]:
+        return {
+            "channel": output.channel,
+            "message": self.topic_message_data(output.message),
+        }


### PR DESCRIPTION
Basic logging in console. This look like:

```
2022-01-19 15:14:29,934 [DEBUG] saturn.messages: Submitted message - {'message': {'id': '1'}, 'pipeline': 'example.pipelines.echo'}
2022-01-19 15:14:29,934 [DEBUG] saturn.messages: Executing message - {'message': {'id': '1'}, 'pipeline': 'example.pipelines.echo'}
2022-01-19 15:14:29,935 [DEBUG] saturn.messages: Scheduled message - {'message': {'id': '2'}, 'pipeline': 'example.pipelines.echo'}
2022-01-19 15:14:29,935 [DEBUG] saturn_engine.worker.executors.ExecutorManager: locking resources: {'example.resources.TestApiKey'}
2022-01-19 15:14:29,936 [DEBUG] saturn_engine.worker.executors.ExecutorManager: locking resources: {'example.resources.TestApiKey'}
api_key: example-api-key-1 data: {'message': 'hello-1'}
2022-01-19 15:14:29,937 [DEBUG] saturn.messages: Polled message - {'message': {'id': '3'}, 'pipeline': 'example.pipelines.echo'}
2022-01-19 15:14:29,941 [DEBUG] saturn.messages: Executed message - {'message': {'id': '1'}, 'pipeline': 'example.pipelines.echo', 'result': [{'channel': 'default', 'message': {'id': '87336720-91f6-415f-8ea9-d943644525e0'}}]}
```

It has an options (`console_logging.verbose = true`) to adds more data in the logs.