### PR TITLE
bump nox

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-    - run: pip install nox==2021.10.1
-    - run: pip install poetry==1.1.11
-    - run: pip install nox-poetry==0.8.6
+    - run: pip install nox==2022.1.7
+    - run: pip install poetry==1.1.12
+    - run: pip install nox-poetry==0.9.0
     - run: nox

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 .venv-tools:
 	rm -rf venv
 	python -m venv .venv-tools
-	.venv-tools/bin/pip install poetry==1.1.11 nox==2021.10.1 nox-poetry==0.8.6 pip==21.3 || (rm -rf venv && exit 1)
+	.venv-tools/bin/pip install poetry==1.1.12 nox==2022.1.7 nox-poetry==0.9.0 pip==21.3.1 || (rm -rf venv && exit 1)
 
 .PHONY: nox
 nox: .venv-tools


### PR DESCRIPTION
So that this error goes away:

```
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.

nox-poetry 0.8.6 requires tomlkit<0.8.0,>=0.7.0, but you'll have tomlkit 0.8.0 which is incompatible.
```