### PR TITLE
worker-manager(jobs): Allow to set jobs as failed

### DIFF
--- a/example/definitions/simple.yaml
+++ b/example/definitions/simple.yaml
@@ -27,6 +27,11 @@ spec:
     - {message: hello-7}
     - {message: hello-8}
     - {message: hello-9}
+    - {message: hello-10}
+    - {message: hello-11}
+    - {message: hello-12}
+    - {message: hello-13}
+    - {message: hello-14}
 ---
 apiVersion: saturn.flared.io/v1alpha1
 kind: SaturnJobDefinition
@@ -56,4 +61,4 @@ spec:
   type: example.resources.TestApiKey
   data:
     key: example-api-key-1
-  default_delay: 5
+  default_delay: 1

--- a/src/saturn_engine/core/api.py
+++ b/src/saturn_engine/core/api.py
@@ -91,6 +91,7 @@ class JobItem:
     completed_at: Optional[datetime]
     started_at: datetime
     cursor: Optional[str]
+    error: Optional[str]
 
 
 @dataclasses.dataclass

--- a/src/saturn_engine/models/job.py
+++ b/src/saturn_engine/models/job.py
@@ -24,6 +24,7 @@ class Job(Base):
     completed_at: Mapped[Optional[datetime]] = Column(UTCDateTime, nullable=True)  # type: ignore[assignment]  # noqa: B950
     started_at: Mapped[datetime] = Column(UTCDateTime, nullable=False)  # type: ignore[assignment]  # noqa: B950
     queue_name = Column(Text, ForeignKey("queues.name"), nullable=False)
+    error = Column(Text, nullable=True)
     queue: "Queue" = relationship(
         "Queue",
         uselist=False,
@@ -52,6 +53,7 @@ class Job(Base):
             completed_at=self.completed_at,
             started_at=self.started_at,
             cursor=self.cursor,
+            error=self.error,
         )
 
 

--- a/src/saturn_engine/stores/jobs_store.py
+++ b/src/saturn_engine/stores/jobs_store.py
@@ -57,6 +57,7 @@ def update_job(
     *,
     cursor: Optional[str],
     completed_at: Optional[datetime],
+    error: Optional[str],
     session: AnySyncSession,
 ) -> None:
     noop_stmt = stmt = update(Job).where(Job.name == name)
@@ -64,6 +65,8 @@ def update_job(
         stmt = stmt.values(cursor=cursor)
     if completed_at:
         stmt = stmt.values(completed_at=completed_at)
+    if error:
+        stmt = stmt.values(error=error)
 
     if stmt is noop_stmt:
         return

--- a/src/saturn_engine/stores/queues_store.py
+++ b/src/saturn_engine/stores/queues_store.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import joinedload
 
 from saturn_engine.database import AnySession
 from saturn_engine.database import AnySyncSession
+from saturn_engine.models import Job
 from saturn_engine.models import Queue
 
 
@@ -28,11 +29,10 @@ def get_assigned_queues(
     assigned_jobs: list[Queue] = (
         session.execute(
             select(Queue)
-            .options(
-                joinedload(Queue.job),
-            )
+            .join(Queue.job)
             .where(Queue.assigned_to == worker_id)
             .where(Queue.assigned_at >= assigned_after)
+            .where(Job.completed_at == None)  # noqa: E711
             .order_by(Queue.name)
         )
         .scalars()

--- a/src/saturn_engine/worker/broker.py
+++ b/src/saturn_engine/worker/broker.py
@@ -81,7 +81,7 @@ class Broker:
         self.logger.info("Starting worker")
         self.executor.start()
         self.running_task = asyncio.gather(
-            asyncio.create_task(self.run_queue(), name="broker.run"),
+            asyncio.create_task(self.run_queue(), name="broker.run_queue"),
             asyncio.create_task(self.run_sync(), name="broker.sync"),
         )
         try:
@@ -122,9 +122,9 @@ class Broker:
                 await self.resources_manager.add(resource)
 
             for queue in work_sync.queues.drop:
-                self.scheduler.remove(queue)
+                await self.scheduler.remove(queue)
             for resource in work_sync.resources.drop:
-                self.resources_manager.remove(resource)
+                await self.resources_manager.remove(resource)
 
     async def close(self) -> None:
         await self.scheduler.close()

--- a/src/saturn_engine/worker/resources_manager.py
+++ b/src/saturn_engine/worker/resources_manager.py
@@ -153,5 +153,5 @@ class ResourcesManager:
     async def add(self, resource: ResourceData) -> None:
         await self.resources[resource.type].add(resource)
 
-    def remove(self, resource: ResourceData) -> None:
-        self.resources[resource.type].remove(resource)
+    async def remove(self, resource: ResourceData) -> None:
+        await self.resources[resource.type].remove(resource)

--- a/src/saturn_engine/worker/services/job_store.py
+++ b/src/saturn_engine/worker/services/job_store.py
@@ -35,4 +35,4 @@ class JobStoreService(Service["JobStoreService.Services", None]):
 
     async def close(self) -> None:
         for store in self.api_stores:
-            store.flush()
+            await store.flush()

--- a/src/saturn_engine/worker_manager/api/jobs.py
+++ b/src/saturn_engine/worker_manager/api/jobs.py
@@ -44,6 +44,7 @@ def update_job(job_name: str) -> Json[UpdateResponse]:
             job_name,
             cursor=update_input.cursor,
             completed_at=update_input.completed_at,
+            error=update_input.error,
             session=session,
         )
         return jsonify(UpdateResponse())

--- a/tests/worker_manager/api/test_jobs.py
+++ b/tests/worker_manager/api/test_jobs.py
@@ -1,5 +1,7 @@
+import time
 from datetime import timedelta
 
+import werkzeug.test
 from flask.testing import FlaskClient
 from sqlalchemy.orm import Session
 
@@ -10,6 +12,10 @@ from saturn_engine.utils import utcnow
 from saturn_engine.worker_manager.config.declarative import StaticDefinitions
 from saturn_engine.worker_manager.config.declarative import load_definitions_from_str
 from tests.conftest import FreezeTime
+
+
+def ids(response: werkzeug.test.TestResponse) -> set[str]:
+    return {i["name"] for i in (response.json or {}).get("items", [])}
 
 
 def test_api_jobs(
@@ -43,6 +49,7 @@ def test_api_jobs(
                 "name": job.name,
                 "completed_at": None,
                 "cursor": None,
+                "error": None,
                 "started_at": "2018-01-02T00:00:00+00:00",
             }
         ]
@@ -79,6 +86,7 @@ def test_api_job(
             "completed_at": None,
             "cursor": None,
             "started_at": "2018-01-02T00:00:00+00:00",
+            "error": None,
         }
     }
 
@@ -116,6 +124,7 @@ def test_api_update_job(
             "name": job.name,
             "completed_at": None,
             "cursor": "1",
+            "error": None,
             "started_at": "2018-01-02T00:00:00+00:00",
         }
     }
@@ -135,6 +144,7 @@ def test_api_update_job(
             "name": job.name,
             "completed_at": "2018-01-02T00:00:00+00:00",
             "cursor": "2",
+            "error": None,
             "started_at": "2018-01-02T00:00:00+00:00",
         }
     }
@@ -269,18 +279,21 @@ spec:
                 "completed_at": None,
                 "started_at": "2017-12-25T00:00:00+00:00",
                 "cursor": None,
+                "error": None,
                 "name": "running",
             },
             {
                 "completed_at": "2018-01-01T00:00:00+00:00",
                 "started_at": "2017-12-25T00:00:00+00:00",
                 "cursor": None,
+                "error": None,
                 "name": "due",
             },
             {
                 "completed_at": "2018-01-01T00:00:00+00:00",
                 "started_at": "2017-12-31T00:00:00+00:00",
                 "cursor": None,
+                "error": None,
                 "name": "not-due",
             },
         ]
@@ -298,6 +311,7 @@ spec:
                 # Running job was untouched
                 "completed_at": None,
                 "cursor": None,
+                "error": None,
                 "name": "running",
                 "started_at": "2017-12-25T00:00:00+00:00",
             },
@@ -305,6 +319,7 @@ spec:
                 # The old due job, untouched
                 "completed_at": "2018-01-01T00:00:00+00:00",
                 "cursor": None,
+                "error": None,
                 "name": "due",
                 "started_at": "2017-12-25T00:00:00+00:00",
             },
@@ -312,6 +327,7 @@ spec:
                 # The not-due job, untouched
                 "completed_at": "2018-01-01T00:00:00+00:00",
                 "cursor": None,
+                "error": None,
                 "name": "not-due",
                 "started_at": "2017-12-31T00:00:00+00:00",
             },
@@ -319,6 +335,7 @@ spec:
                 # Unscheduled job was scheduled
                 "completed_at": None,
                 "cursor": None,
+                "error": None,
                 "name": "unscheduled-1514851200",
                 "started_at": "2018-01-02T00:00:00+00:00",
             },
@@ -326,6 +343,7 @@ spec:
                 # The due job was scheduled
                 "completed_at": None,
                 "cursor": None,
+                "error": None,
                 "name": "due-1514851200",
                 "started_at": "2018-01-02T00:00:00+00:00",
             },
@@ -344,3 +362,84 @@ spec:
     resp = client.get("/api/jobs")
     assert resp.status_code == 200
     assert resp.json == expected_response
+
+
+def test_failed_jobs(
+    client: FlaskClient,
+    session: Session,
+    static_definitions: StaticDefinitions,
+    frozen_time: FreezeTime,
+) -> None:
+    # Add a job
+    new_definitions_str: str = """
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnInventory
+metadata:
+  name: test-inventory
+spec:
+  type: testtype
+  options: {}
+---
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnJobDefinition
+metadata:
+  name: test
+spec:
+  minimalInterval: "@weekly"
+  template:
+    name: test
+    input:
+      inventory: test-inventory
+    pipeline:
+      name: something.saturn.pipelines.aa.bb
+"""
+    new_definitions = load_definitions_from_str(new_definitions_str)
+    static_definitions.job_definitions = new_definitions.job_definitions
+
+    queue = queues_store.create_queue(session=session, name="test")
+    session.flush()
+    job = jobs_store.create_job(
+        name="test",
+        session=session,
+        queue_name=queue.name,
+        job_definition_name="test",
+        started_at=utcnow() - timedelta(days=1),
+    )
+    session.commit()
+
+    # Lock jobs
+    resp = client.post("/api/lock", json={"worker_id": "worker-1"})
+    assert resp.status_code == 200
+    assert ids(resp) == {"test"}
+
+    # Fail the job
+    resp = client.put(
+        f"/api/jobs/{job.name}",
+        json={
+            "cursor": "3",
+            "completed_at": "2018-01-02T00:00:00+00:00",
+            "error": "ValueError('oops')",
+        },
+    )
+    assert resp.status_code == 200
+
+    # Lock jobs
+    resp = client.post("/api/lock", json={"worker_id": "worker-1"})
+    assert resp.status_code == 200
+    assert not ids(resp)
+
+    # Sync jobs again to spawn a new job.
+    resp = client.post("/api/jobs/sync")
+    assert resp.status_code == 200
+    assert resp.json == {}
+
+    # Lock jobs
+    resp = client.post("/api/lock", json={"worker_id": "worker-1"})
+    new_job_name = f"test-{int(time.time())}"
+    assert resp.status_code == 200
+    assert ids(resp) == {new_job_name}
+
+    # Cursor should resume where it was at.
+    resp = client.get(f"/api/jobs/{new_job_name}")
+    assert resp.status_code == 200
+    assert resp.json and resp.json["data"]["cursor"] == "3"


### PR DESCRIPTION
Second part of https://github.com/Flared/saturn/pull/110

Implement the Worker-Manager API side.

It also add the useful feature of not lock completed jobs and fix a few missing await I saw thanks to the logs 🤔 