### PR TITLE
tester: show an inv sample

### DIFF
--- a/example/run_tests
+++ b/example/run_tests
@@ -3,6 +3,15 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export PYTHONPATH="${PYTHONPATH}:$DIR/src"
 
-python -m saturn_engine.utils.tester.runner \
+
+echo "Showing one sample of static-inventory..."
+python -m saturn_engine.utils.tester.runner show-inventory \
+    --topology=example/definitions/simple.yaml \
+    --limit=1 \
+    --after=1 \
+    --name=static-inventory
+
+echo "Running YAML tests..."
+python -m saturn_engine.utils.tester.runner run \
     --topology=example/definitions/simple.yaml \
     --tests=example/tests

--- a/src/saturn_engine/utils/tester/inventory_test.py
+++ b/src/saturn_engine/utils/tester/inventory_test.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import asyncio
 
 from saturn_engine.config import default_config_with_env
@@ -10,37 +12,47 @@ from .config.inventory_test import InventoryTest
 from .diff import get_diff
 
 
-def run_saturn_inventory_test(
+def run_saturn_inventory(
     *,
     static_definitions: StaticDefinitions,
-    inventory_test: InventoryTest,
-) -> None:
-
-    inventory_item = static_definitions.inventories[
-        inventory_test.spec.selector.inventory
-    ]
-
+    inventory_name: str,
+    limit: Optional[int] = None,
+    after: Optional[str] = None,
+) -> list[dict]:
+    inventory_item = static_definitions.inventories[inventory_name]
     inventory = work_factory.build_inventory(
         inventory_item=inventory_item,
         services=ServicesManager(
             config=default_config_with_env(),
         ).services,
     )
-
     items: list[dict] = []
 
     async def run_inventory() -> None:
-        limit = inventory_test.spec.limit
         count = 0
-        async for item in inventory.iterate(
-            after=inventory_test.spec.after,
-        ):
+        async for item in inventory.iterate(after=after):
             items.append(asdict(item))
             count = count + 1
             if limit and count >= limit:
                 break
 
     asyncio.run(run_inventory())
+
+    return items
+
+
+def run_saturn_inventory_test(
+    *,
+    static_definitions: StaticDefinitions,
+    inventory_test: InventoryTest,
+) -> None:
+
+    items: list[dict] = run_saturn_inventory(
+        static_definitions=static_definitions,
+        inventory_name=inventory_test.spec.selector.inventory,
+        limit=inventory_test.spec.limit,
+        after=inventory_test.spec.after,
+    )
 
     expected_items: list[dict] = [asdict(item) for item in inventory_test.spec.items]
 


### PR DESCRIPTION
Show inventory samples using commands like this:
```bash
python -m saturn_engine.utils.tester.runner show-inventory \
    --topology=example/definitions/simple.yaml \
    --limit=1 \
    --after=1 \
    --name=static-inventory
```