### PR TITLE
worker: Wrap executor exception in RemoteException

### DIFF
--- a/example/ray
+++ b/example/ray
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$( cd ${DIR}/.. && pwd )"
+
+export PYTHONPATH="${PYTHONPATH}:$DIR/src"
+exec ray start --head --port=6379
+

--- a/src/saturn_engine/utils/traceback_data.py
+++ b/src/saturn_engine/utils/traceback_data.py
@@ -1,0 +1,280 @@
+import typing as t
+
+import collections
+import dataclasses
+import itertools
+import linecache
+import sys
+import traceback
+from types import FrameType
+from types import TracebackType
+
+_RECURSIVE_CUTOFF = 3  # Also hardcoded in traceback.c.
+
+_cause_message = (
+    "\nThe above exception was the direct cause " "of the following exception:\n\n"
+)
+
+_context_message = (
+    "\nDuring handling of the above exception, " "another exception occurred:\n\n"
+)
+
+
+@dataclasses.dataclass
+class TracebackData:
+    """Very alike traceback.TracebackException, with a few tweak to ensure
+    100% serializability and some life-improvers:
+     * `exc_type` is not a Type, but a descriptive str.
+     * Add `exc_args`, a serializable tuple of `exc.args`.
+     * Add `lines_[before|after]` to get context around frames lines.
+    """
+
+    exc_type: str
+    exc_module: str
+    exc_str: str
+    stack: list["FrameData"]
+    truncated: bool = False
+    __cause__: t.Optional["TracebackData"] = None
+    __context__: t.Optional["TracebackData"] = None
+    __suppress_context__: bool = False
+
+    @classmethod
+    def from_exception(
+        cls, exc: BaseException, *, _seen: t.Optional[set[int]] = None
+    ) -> "TracebackData":
+        return cls.from_exc_info(type(exc), exc, exc.__traceback__)
+
+    @classmethod
+    def from_exc_info(
+        cls,
+        exc_type: t.Type[BaseException],
+        exc_value: BaseException,
+        exc_traceback: t.Optional[TracebackType],
+        *,
+        _seen: t.Optional[set[int]] = None,
+    ) -> "TracebackData":
+        if _seen is None:
+            _seen = set()
+        _seen.add(id(exc_value))
+
+        truncated = False
+        cause = None
+        context = None
+        try:
+            if exc_value.__cause__ and id(exc_value.__cause__) not in _seen:
+                cause = cls.from_exception(exc_value.__cause__)
+            if exc_value.__context__ and id(exc_value.__context__) not in _seen:
+                context = cls.from_exception(exc_value.__context__)
+        except RecursionError:
+            # The recursive call to the constructors above
+            # may result in a stack overflow for long exception chains,
+            # so we must truncate.
+            truncated = True
+
+        stack = cls.extract_stack(traceback.walk_tb(exc_traceback))
+        return cls(
+            exc_type=exc_type.__qualname__,
+            exc_module=exc_type.__module__,
+            exc_str=_some_str(exc_value),
+            stack=stack,
+            truncated=truncated,
+            __cause__=cause,
+            __context__=context,
+            __suppress_context__=exc_value.__suppress_context__,
+        )
+
+    def __str__(self) -> str:
+        return self.exc_str
+
+    @staticmethod
+    def extract_stack(
+        frame_gen: t.Iterator[tuple[FrameType, int]], *, line_context: int = 2
+    ) -> list["FrameData"]:
+        limit = getattr(sys, "tracebacklimit", None)
+        if limit is not None and limit < 0:
+            limit = 0
+        if limit is not None:
+            if limit >= 0:
+                frame_gen = itertools.islice(frame_gen, limit)
+            else:
+                frame_gen = iter(collections.deque(frame_gen, maxlen=-limit))
+
+        result = []
+        fnames = set()
+
+        for f, lineno in frame_gen:
+            co = f.f_code
+            filename = co.co_filename
+            name = co.co_name
+            module = f.f_globals.get("__name__", "")
+
+            fnames.add(filename)
+            linecache.lazycache(filename, f.f_globals)
+            f_locals = f.f_locals
+            _locals: dict[str, str] = (
+                {k: repr(v) for k, v in f_locals.items()} if f_locals else {}
+            )
+
+            firstlineno = co.co_firstlineno
+            lastlineno = firstlineno + sum(x for x in co.co_lnotab[1::2])
+            lines_before = []
+            lines_after = []
+            line = linecache.getline(filename, lineno).rstrip()
+            for i in range(
+                max(co.co_firstlineno, lineno - line_context, line_context), lineno
+            ):
+                lines_before.append(linecache.getline(filename, i).rstrip())
+            for i in range(lineno + 1, min(lastlineno, lineno + line_context) + 1):
+                lines_after.append(linecache.getline(filename, i).rstrip())
+
+            # Must defer line lookups until we have called checkcache.
+            result.append(
+                FrameData(
+                    filename=filename,
+                    lineno=lineno,
+                    module=module,
+                    name=name,
+                    lines_before=lines_before,
+                    line=line,
+                    lines_after=lines_after,
+                    locals=_locals,
+                )
+            )
+        return result
+
+    def format_exception_only(self) -> str:
+        """Format the exception part of the traceback.
+
+        The return value is a generator of strings, each ending in a newline.
+
+        Normally, the generator emits a single string; however, for
+        SyntaxError exceptions, it emits several lines that (when
+        printed) display detailed information about where the syntax
+        error occurred.
+
+        The message indicating which exception occurred is always the last
+        string in the output.
+        """
+        stype = self.exc_type
+        smod = self.exc_module
+        if smod not in ("__main__", "builtins"):
+            stype = smod + "." + stype
+
+        return _format_final_exc_line(stype, self.exc_str)
+
+    def format(
+        self,
+        *,
+        chain: bool = True,
+        include_line: bool = True,
+        include_locals: bool = False,
+    ) -> t.Iterator[str]:
+        """Format the exception.
+
+        If chain is not *True*, *__cause__* and *__context__* will not be formatted.
+
+        The return value is a generator of strings, each ending in a newline and
+        some containing internal newlines. `print_exception` is a wrapper around
+        this method which just prints the lines to a file.
+
+        The message indicating which exception occurred is always the last
+        string in the output.
+        """
+        if chain:
+            if self.__cause__ is not None:
+                yield from self.__cause__.format(chain=chain)
+                yield _cause_message
+            elif self.__context__ is not None and not self.__suppress_context__:
+                yield from self.__context__.format(chain=chain)
+                yield _context_message
+            if self.truncated:
+                yield (
+                    "Chained exceptions have been truncated to avoid "
+                    "stack overflow in traceback formatting:\n"
+                )
+        if self.stack:
+            yield "Traceback (most recent call last):\n"
+            yield from self.format_stack()
+        yield self.format_exception_only()
+
+    def format_stack(
+        self, *, include_line: bool = True, include_locals: bool = False
+    ) -> t.Iterator[str]:
+        """Format the stack ready for printing.
+
+        Returns a list of strings ready for printing.  Each string in the
+        resulting list corresponds to a single frame from the stack.
+        Each string ends in a newline; the strings may contain internal
+        newlines as well, for those items with source text lines.
+
+        For long sequences of the same frame and line, the first few
+        repetitions are shown, followed by a summary line stating the exact
+        number of further repetitions.
+        """
+        last_file = None
+        last_line = None
+        last_name = None
+        count = 0
+        for frame in self.stack:
+            if (
+                last_file is None
+                or last_file != frame.filename
+                or last_line is None
+                or last_line != frame.lineno
+                or last_name is None
+                or last_name != frame.name
+            ):
+                if count > _RECURSIVE_CUTOFF:
+                    count -= _RECURSIVE_CUTOFF
+                    yield (
+                        f"  [Previous line repeated {count} more "
+                        f'time{"s" if count > 1 else ""}]\n'
+                    )
+                last_file = frame.filename
+                last_line = frame.lineno
+                last_name = frame.name
+                count = 0
+            count += 1
+            if count > _RECURSIVE_CUTOFF:
+                continue
+            yield '  File "{}", line {}, in {}\n'.format(
+                frame.filename, frame.lineno, frame.name
+            )
+            if include_line and frame.line:
+                yield "    {}\n".format(frame.line.strip())
+            if include_locals and frame.locals:
+                for name, value in sorted(frame.locals.items()):
+                    yield "    {name} = {value}\n".format(name=name, value=value)
+        if count > _RECURSIVE_CUTOFF:
+            count -= _RECURSIVE_CUTOFF
+            yield (
+                f"  [Previous line repeated {count} more "
+                f'time{"s" if count > 1 else ""}]\n'
+            )
+
+
+@dataclasses.dataclass
+class FrameData:
+    filename: str
+    lineno: int
+    module: str
+    name: str
+    locals: dict[str, str]
+    lines_before: list[str]
+    line: str
+    lines_after: list[str]
+
+
+def _format_final_exc_line(etype: str, value: str) -> str:
+    if not value:
+        line = f"{etype}\n"
+    else:
+        line = f"{etype}: {value}\n"
+    return line
+
+
+def _some_str(value: object) -> str:
+    try:
+        return str(value)
+    except Exception:
+        return f"<unprintable {type(value).__name__} object>"

--- a/src/saturn_engine/worker/broker.py
+++ b/src/saturn_engine/worker/broker.py
@@ -101,7 +101,6 @@ class Broker:
         """
         # Go through all queue in the Ready state.
         async for message in self.scheduler.run():
-            self.logger.debug("Processing message: %s", message)
             await self.services_manager.services.s.hooks.message_scheduled.emit(
                 message.message
             )

--- a/src/saturn_engine/worker/executors/bootstrap.py
+++ b/src/saturn_engine/worker/executors/bootstrap.py
@@ -1,4 +1,6 @@
+import contextlib
 import logging
+from collections.abc import Generator
 from collections.abc import Iterable
 from collections.abc import Iterator
 
@@ -6,6 +8,7 @@ from saturn_engine.core import PipelineOutput
 from saturn_engine.core import PipelineResult
 from saturn_engine.core import ResourceUsed
 from saturn_engine.core import TopicMessage
+from saturn_engine.utils.traceback_data import TracebackData
 from saturn_engine.worker.pipeline_message import PipelineMessage
 
 
@@ -43,3 +46,35 @@ def bootstrap_pipeline(message: PipelineMessage) -> PipelineResult:
             logger.error("Invalid result type: %s", result.__class__)
 
     return PipelineResult(outputs=outputs, resources=resources)
+
+
+class RemoteException(Exception):
+    def __init__(self, tb: TracebackData):
+        super().__init__(tb)
+        self.remote_traceback = tb
+
+    @classmethod
+    def from_exception(cls, exception: Exception) -> "RemoteException":
+        tb = TracebackData.from_exception(exception)
+        return cls(tb)
+
+    def __str__(self) -> str:
+        return (
+            self.remote_traceback.format_exception_only()
+            + "\nRemoteException "
+            + "".join(self.remote_traceback.format())
+        )
+
+    def __repr__(self) -> str:
+        stype = f"RemoteException[{self.remote_traceback.exc_type}]"
+        if self.remote_traceback.exc_str.startswith("("):
+            return stype + self.remote_traceback.exc_str
+        return stype + f"({self.remote_traceback.exc_str})"
+
+
+@contextlib.contextmanager
+def wrap_remote_exception() -> Generator[None, None, None]:
+    try:
+        yield
+    except Exception as e:
+        raise RemoteException.from_exception(e) from None

--- a/src/saturn_engine/worker/executors/ray.py
+++ b/src/saturn_engine/worker/executors/ray.py
@@ -8,11 +8,13 @@ from saturn_engine.worker.pipeline_message import PipelineMessage
 from ..services import Services
 from . import Executor
 from .bootstrap import bootstrap_pipeline
+from .bootstrap import wrap_remote_exception
 
 
 @ray.remote
 def ray_execute(message: PipelineMessage) -> PipelineResult:
-    return bootstrap_pipeline(message)
+    with wrap_remote_exception():
+        return bootstrap_pipeline(message)
 
 
 class RayExecutor(Executor):

--- a/src/saturn_engine/worker/services/loggers/logger.py
+++ b/src/saturn_engine/worker/services/loggers/logger.py
@@ -82,7 +82,8 @@ class Logger(Service[BaseServices, "Logger.Options"]):
             )
         except Exception:
             self.message_logger.exception(
-                "Failed to execute message", extra={"data": self.message_data(message)}
+                "Failed to execute message",
+                extra={"data": self.message_data(message)},
             )
 
     async def on_message_published(

--- a/tests/worker/test_bootstrap.py
+++ b/tests/worker/test_bootstrap.py
@@ -1,0 +1,89 @@
+from typing import Optional
+
+import pickle  # noqa: S403
+
+from saturn_engine.worker.executors.bootstrap import RemoteException
+from saturn_engine.worker.executors.bootstrap import wrap_remote_exception
+
+
+class MyError(Exception):
+    pass
+
+
+def raises(
+    e: Exception,
+    *,
+    cause: Optional[Exception] = None,
+    context: Optional[Exception] = None
+) -> None:
+    x = {"foo": "bar"}  # noqa: F841
+    try:
+        if context:
+            raise context
+    finally:
+        raise e from cause
+
+
+def raises_remote(
+    e: Exception,
+    *,
+    cause: Optional[Exception] = None,
+    context: Optional[Exception] = None
+) -> None:
+    try:
+        # That would be in a remote process
+        with wrap_remote_exception():
+            raises(e, cause=cause, context=context)
+    except Exception as e:
+        remote_error = pickle.dumps(e)
+    else:
+        raise AssertionError()
+
+    # And we would be back in the host process
+    local_error = pickle.loads(remote_error)  # noqa: S301
+    raise local_error
+
+
+def test_remote_exception() -> None:
+    try:
+        raises_remote(ValueError("test", 1))
+        raise AssertionError
+    except RemoteException as e:
+        assert isinstance(e, RemoteException)
+        assert e.remote_traceback.__cause__ is None
+        assert e.remote_traceback.__context__ is None
+        assert e.remote_traceback.exc_type == "ValueError"
+        assert e.remote_traceback.stack[-1].line.strip() == "raise e from cause"
+        assert e.remote_traceback.stack[-1].locals["x"] == "{'foo': 'bar'}"
+
+    try:
+        raises_remote(MyError("test", 1), cause=ValueError("cause"))
+        raise AssertionError
+    except RemoteException as e:
+        assert isinstance(e, RemoteException)
+        assert e.remote_traceback.__cause__ is not None
+        assert e.remote_traceback.__cause__.exc_type == "ValueError"
+        assert e.remote_traceback.__cause__.stack == []
+
+        assert e.remote_traceback.__context__ is None
+        assert e.remote_traceback.exc_type == "MyError"
+        assert e.remote_traceback.stack[-1].line.strip() == "raise e from cause"
+        assert e.remote_traceback.stack[-1].locals["x"] == "{'foo': 'bar'}"
+
+    try:
+        raises_remote(
+            MyError("test", 1), cause=ValueError("cause"), context=ValueError("context")
+        )
+        raise AssertionError
+    except RemoteException as e:
+        assert isinstance(e, RemoteException)
+        assert e.remote_traceback.__cause__ is not None
+        assert e.remote_traceback.__cause__.exc_type == "ValueError"
+        assert e.remote_traceback.__context__ is not None
+        assert e.remote_traceback.__context__.exc_type == "ValueError"
+        assert e.remote_traceback.__context__.stack[-1].line.strip() == "raise context"
+
+        assert e.remote_traceback.exc_type == "MyError"
+        assert e.remote_traceback.stack[-1].line.strip() == "raise e from cause"
+        assert e.remote_traceback.stack[-1].locals
+        assert e.remote_traceback.stack[-1].locals["x"] == "{'foo': 'bar'}"


### PR DESCRIPTION
The wrapper save the traceback as a serialized TracebackException object so it can be used in the worker to sent a more detailed traceback to Sentry.

See: https://sentry.io/organizations/flare-systems/issues/2958701849/?project=6159273&query=is%3Aunresolved

Eventually it could be extended to includes module and context (lines before and after) information. But that look good enough for now.