### PR TITLE
sync: commit often

### DIFF
--- a/src/saturn_engine/worker_manager/services/sync.py
+++ b/src/saturn_engine/worker_manager/services/sync.py
@@ -54,3 +54,5 @@ def sync_jobs(
                     # If the last job was an error, we resume from where we were.
                     if last_job and last_job.error:
                         job.cursor = last_job.cursor
+
+                    session.commit()


### PR DESCRIPTION
Investigating an issue where two instances of the worker exist at the same time during a new deploy in k8s, and there *could* be a race condition here, even if its unlikely.

I am thinking that we could commit after each iteration of the loop to help reduce the probability of race conditions.