### PR TITLE
worker_manager: don't assign completed jobs

### DIFF
--- a/src/saturn_engine/config_definitions.py
+++ b/src/saturn_engine/config_definitions.py
@@ -26,6 +26,7 @@ class WorkerManagerConfig:
     database_url: str
     async_database_url: str
     static_definitions_directory: str
+    work_items_per_worker: int
 
 
 @dataclasses.dataclass

--- a/src/saturn_engine/default_config.py
+++ b/src/saturn_engine/default_config.py
@@ -44,3 +44,4 @@ class config(SaturnConfig):
         static_definitions_directory: str = os.environ.get(
             "SATURN_STATIC_DEFINITIONS_DIR", "/opt/saturn/definitions"
         )
+        work_items_per_worker = 10

--- a/src/saturn_engine/models/job.py
+++ b/src/saturn_engine/models/job.py
@@ -40,12 +40,14 @@ class Job(Base):
         job_definition_name: str,
         completed_at: Optional[datetime] = None,
         started_at: Optional[datetime] = None,
+        error: Optional[str] = None,
     ) -> None:
         self.name = name
         self.queue_name = queue_name
         self.job_definition_name = job_definition_name
         self.completed_at = completed_at
         self.started_at = started_at or utcnow()
+        self.error = error
 
     def as_core_item(self) -> JobItem:
         return JobItem(

--- a/src/saturn_engine/stores/jobs_store.py
+++ b/src/saturn_engine/stores/jobs_store.py
@@ -19,6 +19,7 @@ def create_job(
     job_definition_name: str,
     completed_at: Optional[datetime] = None,
     started_at: Optional[datetime] = None,
+    error: Optional[str] = None,
 ) -> Job:
     job = Job(
         name=name,
@@ -26,6 +27,7 @@ def create_job(
         job_definition_name=job_definition_name,
         completed_at=completed_at,
         started_at=started_at,
+        error=error,
     )
     session.add(job)
     return job

--- a/src/saturn_engine/worker_manager/api/lock.py
+++ b/src/saturn_engine/worker_manager/api/lock.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 from datetime import datetime
 from datetime import timedelta
 
@@ -16,95 +17,93 @@ from saturn_engine.worker_manager.app import current_app
 
 bp = Blueprint("lock", __name__, url_prefix="/api/lock")
 
+_LOCK_LOCK = threading.Lock()
+
 
 @bp.route("", methods=("POST",))
 def post_lock() -> Json[LockResponse]:
-    logger = logging.getLogger(f"{__name__}.post_lock")
-    lock_input = marshall_request(LockInput)
+    with _LOCK_LOCK:
+        logger = logging.getLogger(f"{__name__}.post_lock")
+        lock_input = marshall_request(LockInput)
 
-    # Note:
-    # - For now, we just assign 10 items per worker.
-    # - Leftover items remain unassigned.
-    # - TODO(aviau): Acquire the "assignation lock".
-    # - TODO(aviau) Don't assign jobs that are not due to run.
-    # - TODO(aviau): Instead of assigning 10 items, assign based on
-    #                worker capacity and/or number of active workers.
+        # Note:
+        # - Leftover items remain unassigned.
 
-    assignation_expiration_cutoff: datetime = datetime.now() - timedelta(minutes=15)
-    max_assigned_items: int = 10
+        assignation_expiration_cutoff: datetime = datetime.now() - timedelta(minutes=15)
+        max_assigned_items: int = current_app.saturn.config.work_items_per_worker
 
-    assigned_items: list[Queue] = []
+        assigned_items: list[Queue] = []
 
-    with session_scope() as session:
+        with session_scope() as session:
 
-        # Obtains items that were already assigned.
-        assigned_items.extend(
-            queues_store.get_assigned_queues(
-                session=session,
-                worker_id=lock_input.worker_id,
-                assigned_after=assignation_expiration_cutoff,
-            )
-        )
-
-        # Unassign extra items.
-        for unassigned_item in assigned_items[max_assigned_items:]:
-            unassigned_item.assigned_at = None
-            unassigned_item.assigned_to = None
-
-        assigned_items = assigned_items[:10]
-
-        # Obtain new queues
-        if len(assigned_items) < max_assigned_items:
+            # Obtains items that were already assigned.
             assigned_items.extend(
-                queues_store.get_unassigned_queues(
+                queues_store.get_assigned_queues(
                     session=session,
-                    assigned_before=assignation_expiration_cutoff,
-                    limit=max_assigned_items - len(assigned_items),
+                    worker_id=lock_input.worker_id,
+                    assigned_after=assignation_expiration_cutoff,
                 )
             )
 
-        for item in assigned_items:
-            item.join_definitions(current_app.saturn.static_definitions)
+            # Unassign extra items.
+            for unassigned_item in assigned_items[max_assigned_items:]:
+                unassigned_item.assigned_at = None
+                unassigned_item.assigned_to = None
 
-        # Collect resource for assigned work
-        static_definitions = current_app.saturn.static_definitions
-        resources = {}
-        # Copy list since the iteration could drop items from assigned_items.
-        for item in assigned_items.copy():
-            item_resources = {}
-            for resource_type in item.queue_item.pipeline.info.resources.values():
-                pipeline_resources = static_definitions.resources_by_type.get(
-                    resource_type
-                )
-                if not pipeline_resources:
-                    logger.error(
-                        "Skipping queue item, resource missing: item=%s, "
-                        "resource=%s",
-                        item.name,
-                        resource_type,
+            assigned_items = assigned_items[:max_assigned_items]
+
+            # Obtain new queues
+            if len(assigned_items) < max_assigned_items:
+                assigned_items.extend(
+                    queues_store.get_unassigned_queues(
+                        session=session,
+                        assigned_before=assignation_expiration_cutoff,
+                        limit=max_assigned_items - len(assigned_items),
                     )
-                    # Do not update assign the object in the database.
-                    assigned_items.remove(item)
-                    break
+                )
 
-                item_resources.update({r.name: r for r in pipeline_resources})
-            # Didn't break out due to resource missing.
-            else:
-                resources.update(item_resources)
+            for item in assigned_items:
+                item.join_definitions(current_app.saturn.static_definitions)
 
-        # Refresh assignments
-        new_assigned_at = datetime.now()
-        for assigned_item in assigned_items:
-            assigned_item.assigned_at = new_assigned_at
-            assigned_item.assigned_to = lock_input.worker_id
+            # Collect resource for assigned work
+            static_definitions = current_app.saturn.static_definitions
+            resources = {}
+            # Copy list since the iteration could drop items from assigned_items.
+            for item in assigned_items.copy():
+                item_resources = {}
+                for resource_type in item.queue_item.pipeline.info.resources.values():
+                    pipeline_resources = static_definitions.resources_by_type.get(
+                        resource_type
+                    )
+                    if not pipeline_resources:
+                        logger.error(
+                            "Skipping queue item, resource missing: item=%s, "
+                            "resource=%s",
+                            item.name,
+                            resource_type,
+                        )
+                        # Do not update assign the object in the database.
+                        assigned_items.remove(item)
+                        break
 
-        queue_items = []
-        for item in assigned_items:
-            queue_items.append(item.queue_item)
+                    item_resources.update({r.name: r for r in pipeline_resources})
+                # Didn't break out due to resource missing.
+                else:
+                    resources.update(item_resources)
 
-    return jsonify(
-        LockResponse(
-            items=queue_items,
-            resources=list(sorted(resources.values(), key=lambda r: r.name)),
+            # Refresh assignments
+            new_assigned_at = datetime.now()
+            for assigned_item in assigned_items:
+                assigned_item.assigned_at = new_assigned_at
+                assigned_item.assigned_to = lock_input.worker_id
+
+            queue_items = []
+            for item in assigned_items:
+                queue_items.append(item.queue_item)
+
+        return jsonify(
+            LockResponse(
+                items=queue_items,
+                resources=list(sorted(resources.values(), key=lambda r: r.name)),
+            )
         )
-    )


### PR DESCRIPTION
- The lock endpoint has not changed, only changed indentation due to the threading.Lock()
- Make `work_items_per_worker` configurable. Better than a hard-coded default.
- `queue_store`: don't return completed jobs in `get_unassigned_queues`. These will occupy worker slots and eventually grind workers to a halt.
- `queue_store`: don't return errored jobs in `get_assigned_queues`. It would cause workers keeping errored jobs.