### PR TITLE
disable queues

### DIFF
--- a/src/saturn_engine/models/job.py
+++ b/src/saturn_engine/models/job.py
@@ -30,7 +30,7 @@ class Job(Base):
     cursor = Column(Text, nullable=True)
     completed_at: Mapped[Optional[datetime]] = Column(UTCDateTime, nullable=True)  # type: ignore[assignment]  # noqa: B950
     started_at: Mapped[datetime] = Column(UTCDateTime, nullable=False)  # type: ignore[assignment]  # noqa: B950
-    queue_name = Column(Text, ForeignKey("queues.name"), nullable=False)
+    queue_name: Mapped[str] = Column(Text, ForeignKey("queues.name"), nullable=False)
     error = Column(Text, nullable=True)
     queue: "Queue" = relationship(
         "Queue",

--- a/src/saturn_engine/models/queue.py
+++ b/src/saturn_engine/models/queue.py
@@ -2,8 +2,11 @@ from typing import Optional
 
 import dataclasses
 
+from sqlalchemy import Boolean
 from sqlalchemy import Column
+from sqlalchemy import Index
 from sqlalchemy import Text
+from sqlalchemy import text
 from sqlalchemy.orm import Mapped
 from sqlalchemy.sql.sqltypes import DateTime
 
@@ -15,12 +18,20 @@ from .base import Base
 
 class Queue(Base):
     __tablename__ = "queues"
+    __table_args__ = (
+        Index(
+            "queues_enabled_assigned_at",
+            text("assigned_at"),
+            postgresql_where="enabled",
+        ),
+    )
 
     name: Mapped[str] = Column(Text, primary_key=True)
     assigned_at = Column(DateTime(timezone=True))
     assigned_to = Column(Text)
     job: Optional["Job"]
     _queue_item: Optional[QueueItem] = None
+    enabled = Column(Boolean, default=True, nullable=False)
 
     @property
     def queue_item(self) -> QueueItem:

--- a/src/saturn_engine/stores/jobs_store.py
+++ b/src/saturn_engine/stores/jobs_store.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import joinedload
 from saturn_engine.database import AnySession
 from saturn_engine.database import AnySyncSession
 from saturn_engine.models import Job
+from saturn_engine.stores import queues_store
 
 
 def create_job(
@@ -69,6 +70,12 @@ def update_job(
         stmt = stmt.values(completed_at=completed_at)
     if error:
         stmt = stmt.values(error=error)
+
+    if completed_at:
+        job = get_job(session=session, name=name)
+        if not job:
+            raise Exception("Updating unknown job")
+        queues_store.disable_queue(name=job.queue_name, session=session)
 
     if stmt is noop_stmt:
         return

--- a/tests/worker_manager/api/test_lock.py
+++ b/tests/worker_manager/api/test_lock.py
@@ -1,5 +1,4 @@
 from typing import Callable
-from typing import Optional
 
 from datetime import datetime
 from datetime import timedelta
@@ -47,8 +46,6 @@ def test_api_lock(
 
     def create_job(
         name: str,
-        completed_at: Optional[datetime] = None,
-        error: Optional[str] = None,
     ) -> Job:
         queue = create_queue(name)
         job = jobs_store.create_job(
@@ -56,8 +53,6 @@ def test_api_lock(
             session=session,
             queue_name=queue.name,
             job_definition_name=fake_job_definition.name,
-            completed_at=completed_at,
-            error=error,
         )
         return job
 
@@ -66,8 +61,15 @@ def test_api_lock(
 
     # Create a completed job
     i = i + 1
-    create_job(f"job-{i}", completed_at=utcnow())
-
+    create_job(f"job-{i}")
+    session.commit()
+    jobs_store.update_job(
+        session=session,
+        name=f"job-{i}",
+        cursor="10",
+        completed_at=utcnow(),
+        error=None,
+    )
     session.commit()
 
     expected_items_worker1 = {


### PR DESCRIPTION
This PR fixes an issue where `get_unassigned_queues()` would keep slowing down as we add more and more queues.

The query will slow down because "garbage" queues keep accumulating as we create more and more jobs and these jobs eventually complete. There is no way to add an index on the current table that would speed up this query because we need to join Queues with Jobs to tell if they need to be assigned.

We address this issue by marking queues as disabled on job completion. Then, we add an index for locating enabled queues quickly.

This makes the queues store "self-contained", and it no longer needs to check on Jobs to know if queues should be assigned.

Nothing changes in the API.