### PR TITLE
JobSpec: Removed name and applied changes to tests

### DIFF
--- a/example/definitions/simple.yaml
+++ b/example/definitions/simple.yaml
@@ -40,8 +40,6 @@ metadata:
 spec:
   minimalInterval: "@weekly"
   template:
-    name: example-job
-
     input:
       inventory: static-inventory
 

--- a/src/saturn_engine/worker_manager/config/declarative_job.py
+++ b/src/saturn_engine/worker_manager/config/declarative_job.py
@@ -30,17 +30,17 @@ class JobOutput:
 
 @dataclasses.dataclass
 class JobSpec:
-    name: str
     input: JobInput
     pipeline: PipelineInfo
     output: dict[str, list[JobOutput]] = dataclasses.field(default_factory=dict)
 
     def to_core_object(
         self,
+        name: str,
         static_definitions: StaticDefinitions,
     ) -> api.QueueItem:
         return api.QueueItem(
-            name=self.name,
+            name=name,
             input=self.input.to_core_object(static_definitions),
             output={
                 key: [t.to_core_object(static_definitions) for t in topics]
@@ -61,15 +61,4 @@ class Job(BaseObject):
         self,
         static_definitions: StaticDefinitions,
     ) -> api.QueueItem:
-        return api.QueueItem(
-            name=self.metadata.name,
-            input=self.spec.input.to_core_object(static_definitions),
-            output={
-                key: [t.to_core_object(static_definitions) for t in topics]
-                for key, topics in self.spec.output.items()
-            },
-            pipeline=api.QueuePipeline(
-                info=self.spec.pipeline.to_core_object(),
-                args=dict(),
-            ),
-        )
+        return self.spec.to_core_object(self.metadata.name, static_definitions)

--- a/src/saturn_engine/worker_manager/config/declarative_job_definition.py
+++ b/src/saturn_engine/worker_manager/config/declarative_job_definition.py
@@ -24,7 +24,7 @@ class JobDefinition(BaseObject):
         return api.JobDefinition(
             name=self.metadata.name,
             template=self.spec.template.to_core_object(
-                static_definitions,
+                self.metadata.name, static_definitions
             ),
             minimal_interval=self.spec.minimalInterval,
         )

--- a/tests/worker_manager/api/test_job_definitions.py
+++ b/tests/worker_manager/api/test_job_definitions.py
@@ -39,8 +39,6 @@ metadata:
 spec:
   minimalInterval: "@weekly"
   template:
-    name: test
-
     input:
       inventory: test-inventory
 
@@ -69,7 +67,7 @@ spec:
                             "type": "testtype",
                         },
                     },
-                    "name": "test",
+                    "name": "test-job-definition",
                     "output": {
                         "default": [
                             {"name": "test-topic", "options": {}, "type": "RabbitMQ"}

--- a/tests/worker_manager/api/test_jobs.py
+++ b/tests/worker_manager/api/test_jobs.py
@@ -180,7 +180,6 @@ metadata:
 spec:
   minimalInterval: "@weekly"
   template:
-    name: test
     input:
       inventory: test-inventory
     output:
@@ -197,7 +196,6 @@ metadata:
 spec:
   minimalInterval: "@weekly"
   template:
-    name: test
     input:
       inventory: test-inventory
     output:
@@ -214,7 +212,6 @@ metadata:
 spec:
   minimalInterval: "@weekly"
   template:
-    name: test
     input:
       inventory: test-inventory
     output:
@@ -231,7 +228,6 @@ metadata:
 spec:
   minimalInterval: "@weekly"
   template:
-    name: test
     input:
       inventory: test-inventory
     output:
@@ -387,7 +383,6 @@ metadata:
 spec:
   minimalInterval: "@weekly"
   template:
-    name: test
     input:
       inventory: test-inventory
     pipeline:

--- a/tests/worker_manager/config/test_declarative.py
+++ b/tests/worker_manager/config/test_declarative.py
@@ -57,8 +57,6 @@ metadata:
 spec:
   minimalInterval: "@weekly"
   template:
-    name: test
-
     input:
       inventory: test-inventory
 
@@ -102,8 +100,6 @@ metadata:
 spec:
   minimalInterval: "@weekly"
   template:
-    name: test
-
     input:
       inventory: test-inventory
 
@@ -150,8 +146,6 @@ metadata:
 spec:
   minimalInterval: "@weekly"
   template:
-    name: test
-
     input:
       inventory: test-inventory
 
@@ -187,7 +181,6 @@ kind: SaturnJob
 metadata:
   name: test-job
 spec:
-  name: test-job-spec
   input:
     inventory: test-inventory
 
@@ -221,7 +214,6 @@ kind: SaturnJob
 metadata:
   name: test-job
 spec:
-  name: test-job-spec
   input:
     inventory: test-inventory
 
@@ -234,7 +226,6 @@ kind: SaturnJob
 metadata:
   name: test-job-2
 spec:
-  name: test-job-spec
   input:
     inventory: test-inventory
 


### PR DESCRIPTION
I removed the name member from jobspec since it is now
useless.
I also had to modify some tests to take it into account.