### PR TITLE
pytest-markers: removed rabbitmq

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -42,8 +42,6 @@ def tests(session: Session) -> None:
     session.run(
         "pytest",
         "-vv",
-        "-m",
-        "not rabbitmq",
         *args,
         env={"PY_IGNORE_IMPORTMISMATCH": "1"},
     )
@@ -61,22 +59,7 @@ def tests_worker(session: Session) -> None:
     """Worker tests must pass without installing the worker-manager extra."""
     args = session.posargs
     session.install(".", *tests_packages)
-    session.run("pytest", "tests/worker", "-m", "not rabbitmq", *args)
-
-
-@nox_session(python=python_all_versions)
-def tests_rabbitmq(session: Session) -> None:
-    """Tests the rabbitmq"""
-    args = session.posargs
-    session.install(".", "flask", *tests_packages)
-    session.run(
-        "pytest",
-        "-vv",
-        "-m",
-        "rabbitmq",
-        *args,
-        env={"PY_IGNORE_IMPORTMISMATCH": "1"},
-    )
+    session.run("pytest", "tests/worker", *args)
 
 
 @nox_session(python=python_tool_version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,9 +88,6 @@ filterwarnings = [
   "ignore:distutils Version classes are deprecated.:DeprecationWarning",
   "ignore::marshmallow.warnings.RemovedInMarshmallow4Warning",
 ]
-markers = [
-  "rabbitmq: Uses rabbitmq-server from bin/start_local_rabbitmq_server"
-]
 
 [tool.isort]
 profile = "black"

--- a/tests/worker/conftest.py
+++ b/tests/worker/conftest.py
@@ -27,6 +27,7 @@ from saturn_engine.worker.pipeline_message import PipelineMessage
 from saturn_engine.worker.resources_manager import ResourcesManager
 from saturn_engine.worker.services import Services
 from saturn_engine.worker.services.manager import ServicesManager
+from saturn_engine.worker.services.rabbitmq import RabbitMQService
 from saturn_engine.worker.topics import Topic
 from saturn_engine.worker.topics.memory import reset as reset_memory_queues
 from saturn_engine.worker.work_manager import WorkManager
@@ -166,3 +167,14 @@ class FakeResource(Resource):
 @pytest.fixture
 def fake_resource_class() -> str:
     return __name__ + "." + FakeResource.__name__
+
+
+@pytest.fixture
+async def rabbitmq_service(services_manager: ServicesManager) -> RabbitMQService:
+    services_manager._load_service(RabbitMQService)
+    _rabbitmq_service = services_manager.services.rabbitmq
+    try:
+        await _rabbitmq_service.connection
+        return _rabbitmq_service
+    except Exception:
+        raise pytest.skip("No connection to RabbmitMQ server.") from None

--- a/tests/worker/test_rabbitmq_queues.py
+++ b/tests/worker/test_rabbitmq_queues.py
@@ -4,7 +4,6 @@ from collections.abc import Iterator
 import asyncstdlib as alib
 import pytest
 
-from saturn_engine.config import Config
 from saturn_engine.core import TopicMessage
 from saturn_engine.worker.services.manager import ServicesManager
 from saturn_engine.worker.services.rabbitmq import RabbitMQService
@@ -20,26 +19,21 @@ def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
 
 
 @pytest.mark.asyncio
-@pytest.mark.rabbitmq
-async def test_rabbitmq_publish(config: Config) -> None:
-    # Create and open our services manager
-    test_svc_mgr = ServicesManager(config)
-    test_svc_mgr._load_service(RabbitMQService)
-
-    await test_svc_mgr.open()
-
+async def test_rabbitmq_publish(
+    rabbitmq_service: RabbitMQService, services_manager: ServicesManager
+) -> None:
     # Create our test queue and publisher
     queue1 = RabbitMQTopic(
-        RabbitMQTopic.Options("test_queue1", False, True), test_svc_mgr.services
+        RabbitMQTopic.Options("test_queue1", False, True), services_manager.services
     )
     queue2 = RabbitMQTopic(
-        RabbitMQTopic.Options("test_queue2", False, True), test_svc_mgr.services
+        RabbitMQTopic.Options("test_queue2", False, True), services_manager.services
     )
     publisher1 = RabbitMQTopic(
-        RabbitMQTopic.Options("test_queue1", False, True), test_svc_mgr.services
+        RabbitMQTopic.Options("test_queue1", False, True), services_manager.services
     )
     publisher2 = RabbitMQTopic(
-        RabbitMQTopic.Options("test_queue2", False, True), test_svc_mgr.services
+        RabbitMQTopic.Options("test_queue2", False, True), services_manager.services
     )
 
     # Create an asyncgenerator for our messages
@@ -63,4 +57,3 @@ async def test_rabbitmq_publish(config: Config) -> None:
     # Close our connections
     await queue1generator.aclose()
     await queue2generator.aclose()
-    await test_svc_mgr.close()


### PR DESCRIPTION
Rabbitmq tests are now automatically skipped if rabbitmq
is not running.