### PR TITLE
client_config: add missing strict_services key

### DIFF
--- a/src/saturn_engine/default_config.py
+++ b/src/saturn_engine/default_config.py
@@ -51,7 +51,7 @@ class config(SaturnConfig):
 
 
 class client_config(config):
-    class services_manager(ServicesManagerConfig):
+    class services_manager(config.services_manager):
         services = [
             "saturn_engine.worker.services.rabbitmq.RabbitMQService",
         ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ import re
 import pytest
 
 from saturn_engine.config import Config as SaturnConfig
+from saturn_engine.config import default_client_config
 from saturn_engine.config import default_config
 from saturn_engine.utils.config import Config
 
@@ -123,4 +124,8 @@ def test_default_config() -> None:
     # Test default_config can be loaded by itself.
     config = SaturnConfig().load_object(default_config)
     assert config
-    assert True
+
+
+def test_default_client_config() -> None:
+    config = SaturnConfig().load_object(default_client_config)
+    assert config


### PR DESCRIPTION
```python
class client_config(config):
    class services_manager(ServicesManagerConfig):
        services = [
            "saturn_engine.worker.services.rabbitmq.RabbitMQService",
        ]

```
would result in overriding the full `services_manager` object, removing the `strict_services` key