### PR TITLE
PipelineResult -> PipelineResults

### DIFF
--- a/src/saturn_engine/core/__init__.py
+++ b/src/saturn_engine/core/__init__.py
@@ -1,6 +1,7 @@
 from .pipeline import PipelineInfo
 from .pipeline import PipelineOutput
 from .pipeline import PipelineResult
+from .pipeline import PipelineResults
 from .pipeline import QueuePipeline
 from .pipeline import ResourceUsed
 from .resource import Resource
@@ -10,6 +11,7 @@ __all__ = [
     "PipelineInfo",
     "PipelineOutput",
     "PipelineResult",
+    "PipelineResults",
     "QueuePipeline",
     "Resource",
     "ResourceUsed",

--- a/src/saturn_engine/core/pipeline.py
+++ b/src/saturn_engine/core/pipeline.py
@@ -1,6 +1,7 @@
 import typing
 from typing import Any
 from typing import Callable
+from typing import Union
 from typing import cast
 
 import dataclasses
@@ -89,7 +90,10 @@ class ResourceUsed:
         return cls(type=resource._typename(), release_at=release_at)
 
 
+PipelineResult = Union[ResourceUsed, PipelineOutput, TopicMessage]
+
+
 @dataclasses.dataclass
-class PipelineResult:
+class PipelineResults:
     outputs: list[PipelineOutput]
     resources: list[ResourceUsed]

--- a/src/saturn_engine/worker/executors/__init__.py
+++ b/src/saturn_engine/worker/executors/__init__.py
@@ -5,7 +5,7 @@ import contextlib
 from abc import abstractmethod
 
 from saturn_engine.core import PipelineOutput
-from saturn_engine.core import PipelineResult
+from saturn_engine.core import PipelineResults
 from saturn_engine.utils.inspect import import_name
 from saturn_engine.utils.log import getLogger
 from saturn_engine.worker.pipeline_message import PipelineMessage
@@ -22,7 +22,7 @@ class Executor:
         pass
 
     @abstractmethod
-    async def process_message(self, message: PipelineMessage) -> PipelineResult:
+    async def process_message(self, message: PipelineMessage) -> PipelineResults:
         ...
 
     async def close(self) -> None:
@@ -68,7 +68,7 @@ class ExecutorManager:
                 async with processable.context:
 
                     @self.services.hooks.message_executed.emit
-                    async def scope(message: PipelineMessage) -> PipelineResult:
+                    async def scope(message: PipelineMessage) -> PipelineResults:
                         return await self.executor.process_message(message)
 
                     try:

--- a/src/saturn_engine/worker/executors/bootstrap.py
+++ b/src/saturn_engine/worker/executors/bootstrap.py
@@ -5,14 +5,14 @@ from collections.abc import Iterable
 from collections.abc import Iterator
 
 from saturn_engine.core import PipelineOutput
-from saturn_engine.core import PipelineResult
+from saturn_engine.core import PipelineResults
 from saturn_engine.core import ResourceUsed
 from saturn_engine.core import TopicMessage
 from saturn_engine.utils.traceback_data import TracebackData
 from saturn_engine.worker.pipeline_message import PipelineMessage
 
 
-def bootstrap_pipeline(message: PipelineMessage) -> PipelineResult:
+def bootstrap_pipeline(message: PipelineMessage) -> PipelineResults:
     logger = logging.getLogger("pipeline")
     logger.info("Executing %s", message)
     execute_result = message.execute()
@@ -45,7 +45,7 @@ def bootstrap_pipeline(message: PipelineMessage) -> PipelineResult:
         else:
             logger.error("Invalid result type: %s", result.__class__)
 
-    return PipelineResult(outputs=outputs, resources=resources)
+    return PipelineResults(outputs=outputs, resources=resources)
 
 
 class RemoteException(Exception):

--- a/src/saturn_engine/worker/executors/process.py
+++ b/src/saturn_engine/worker/executors/process.py
@@ -2,7 +2,7 @@ import asyncio
 import concurrent.futures
 from functools import partial
 
-from saturn_engine.core import PipelineResult
+from saturn_engine.core import PipelineResults
 from saturn_engine.worker.pipeline_message import PipelineMessage
 from saturn_engine.worker.services import Services
 
@@ -25,7 +25,7 @@ class ProcessExecutor(Executor):
             initializer=process_initializer
         )
 
-    async def process_message(self, message: PipelineMessage) -> PipelineResult:
+    async def process_message(self, message: PipelineMessage) -> PipelineResults:
         loop = asyncio.get_running_loop()
         execute = partial(self.remote_execute, message=message)
         return await loop.run_in_executor(self.pool_executor, execute)
@@ -34,6 +34,6 @@ class ProcessExecutor(Executor):
         self.pool_executor.shutdown(wait=False, cancel_futures=True)
 
     @staticmethod
-    def remote_execute(message: PipelineMessage) -> PipelineResult:
+    def remote_execute(message: PipelineMessage) -> PipelineResults:
         with wrap_remote_exception():
             return bootstrap_pipeline(message)

--- a/src/saturn_engine/worker/executors/ray.py
+++ b/src/saturn_engine/worker/executors/ray.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import ray
 
-from saturn_engine.core import PipelineResult
+from saturn_engine.core import PipelineResults
 from saturn_engine.worker.pipeline_message import PipelineMessage
 
 from ..services import Services
@@ -12,7 +12,7 @@ from .bootstrap import wrap_remote_exception
 
 
 @ray.remote
-def ray_execute(message: PipelineMessage) -> PipelineResult:
+def ray_execute(message: PipelineMessage) -> PipelineResults:
     with wrap_remote_exception():
         return bootstrap_pipeline(message)
 
@@ -26,5 +26,5 @@ class RayExecutor(Executor):
             options["address"] = services.config.c.ray.address
         ray.init(**options)
 
-    async def process_message(self, message: PipelineMessage) -> PipelineResult:
+    async def process_message(self, message: PipelineMessage) -> PipelineResults:
         return await ray_execute.remote(message)

--- a/src/saturn_engine/worker/services/extras/sentry.py
+++ b/src/saturn_engine/worker/services/extras/sentry.py
@@ -13,7 +13,7 @@ from sentry_sdk import Hub
 from sentry_sdk.utils import capture_internal_exceptions
 from sentry_sdk.utils import event_from_exception
 
-from saturn_engine.core import PipelineResult
+from saturn_engine.core import PipelineResults
 from saturn_engine.core.api import QueueItem
 from saturn_engine.utils.options import asdict
 from saturn_engine.utils.traceback_data import FrameData
@@ -92,7 +92,7 @@ class Sentry(Service[BaseServices, "Sentry.Options"]):
 
     async def on_message_executed(
         self, message: PipelineMessage
-    ) -> AsyncGenerator[None, PipelineResult]:
+    ) -> AsyncGenerator[None, PipelineResults]:
         with Hub.current.push_scope() as scope:
 
             def _event_processor(event: Event, hint: Hint) -> Event:

--- a/src/saturn_engine/worker/services/hooks.py
+++ b/src/saturn_engine/worker/services/hooks.py
@@ -1,7 +1,7 @@
 from typing import NamedTuple
 
 from saturn_engine.core import PipelineOutput
-from saturn_engine.core import PipelineResult
+from saturn_engine.core import PipelineResults
 from saturn_engine.core.api import QueueItem
 from saturn_engine.utils.hooks import AsyncContextHook
 from saturn_engine.utils.hooks import AsyncEventHook
@@ -24,7 +24,7 @@ class Hooks:
     message_polled: AsyncEventHook[PipelineMessage]
     message_scheduled: AsyncEventHook[PipelineMessage]
     message_submitted: AsyncEventHook[PipelineMessage]
-    message_executed: AsyncContextHook[PipelineMessage, PipelineResult]
+    message_executed: AsyncContextHook[PipelineMessage, PipelineResults]
     message_published: AsyncContextHook[MessagePublished, None]
 
     work_queue_built: AsyncContextHook[QueueItem, WorkItem]

--- a/src/saturn_engine/worker/services/loggers/logger.py
+++ b/src/saturn_engine/worker/services/loggers/logger.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import AsyncGenerator
 
 from saturn_engine.core import PipelineOutput
-from saturn_engine.core import PipelineResult
+from saturn_engine.core import PipelineResults
 from saturn_engine.core import TopicMessage
 from saturn_engine.core.api import QueueItem
 from saturn_engine.worker.pipeline_message import PipelineMessage
@@ -65,7 +65,7 @@ class Logger(Service[BaseServices, "Logger.Options"]):
 
     async def on_message_executed(
         self, message: PipelineMessage
-    ) -> AsyncGenerator[None, PipelineResult]:
+    ) -> AsyncGenerator[None, PipelineResults]:
         self.message_logger.debug(
             "Executing message", extra={"data": self.message_data(message)}
         )
@@ -118,7 +118,7 @@ class Logger(Service[BaseServices, "Logger.Options"]):
             "id": message.id,
         } | ({"args": message.args} if self.options.verbose else {})
 
-    def result_data(self, results: PipelineResult) -> list[dict[str, Any]]:
+    def result_data(self, results: PipelineResults) -> list[dict[str, Any]]:
         return [self.output_data(o) for o in results.outputs]
 
     def output_data(self, output: PipelineOutput) -> dict[str, Any]:

--- a/src/saturn_engine/worker/services/metrics/base.py
+++ b/src/saturn_engine/worker/services/metrics/base.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from collections.abc import AsyncGenerator
 
-from saturn_engine.core import PipelineResult
+from saturn_engine.core import PipelineResults
 from saturn_engine.worker.pipeline_message import PipelineMessage
 from saturn_engine.worker.services.hooks import MessagePublished
 
@@ -34,7 +34,7 @@ class BaseMetricsService(Generic[TServices, TOptions], Service[TServices, TOptio
 
     async def on_message_executed(
         self, message: PipelineMessage
-    ) -> AsyncGenerator[None, PipelineResult]:
+    ) -> AsyncGenerator[None, PipelineResults]:
         params = {"pipeline": message.info.name}
         await self.incr("message.executed.before", params=params)
         try:

--- a/tests/worker/test_broker.py
+++ b/tests/worker/test_broker.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from saturn_engine.core import PipelineResult
+from saturn_engine.core import PipelineResults
 from saturn_engine.core.api import InventoryItem
 from saturn_engine.core.api import LockResponse
 from saturn_engine.core.api import PipelineInfo
@@ -23,12 +23,12 @@ class FakeExecutor(Executor):
     def __init__(self) -> None:
         self.done_event = asyncio.Event()
 
-    async def process_message(self, message: PipelineMessage) -> PipelineResult:
+    async def process_message(self, message: PipelineMessage) -> PipelineResults:
         assert isinstance(message.message.args["resource"], dict)
         assert message.message.args["resource"]["data"] == "fake"
         if message.message.args["n"] == 999:
             self.done_event.set()
-        return PipelineResult(outputs=[], resources=[])
+        return PipelineResults(outputs=[], resources=[])
 
 
 def pipeline(resource: FakeResource) -> None:

--- a/tests/worker/test_executor.py
+++ b/tests/worker/test_executor.py
@@ -7,7 +7,7 @@ import pytest
 
 from saturn_engine.core import PipelineInfo
 from saturn_engine.core import PipelineOutput
-from saturn_engine.core import PipelineResult
+from saturn_engine.core import PipelineResults
 from saturn_engine.core import TopicMessage
 from saturn_engine.worker.executors import ExecutableMessage
 from saturn_engine.worker.executors import Executor
@@ -27,11 +27,11 @@ class FakeExecutor(Executor):
         self.processing = 0
         self.processed = 0
 
-    async def process_message(self, message: PipelineMessage) -> PipelineResult:
+    async def process_message(self, message: PipelineMessage) -> PipelineResults:
         self.processing += 1
         await self.execute_semaphore.acquire()
         self.processed += 1
-        return PipelineResult(
+        return PipelineResults(
             outputs=[
                 PipelineOutput(
                     channel="default", message=TopicMessage(args={"n": self.processed})


### PR DESCRIPTION
I think the ideal signature for pipelines would be:

```python
def pipeline() -> Iterator[PipelineResult]: ...
```

But I currently have to use:

```python
def pipeline() -> Iterator[Union[PipelineOutput, TopicMessage, ResourceUsed]]: ...
```

This PR would allow for that by creating a `PipelineResult` alias that is a `Union` of `ResourceUsed`, `TopicMessage` and `PipelineOutput`.

The pre-existing `PipelineResult` symbol is pluralized to `PipelineResults` to indicate that it contains multiple results.