### PR TITLE
worker_manager: Load definition from path instead of directory

### DIFF
--- a/src/saturn_engine/config_definitions.py
+++ b/src/saturn_engine/config_definitions.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import dataclasses
 from enum import Enum
 
@@ -21,6 +23,7 @@ class WorkerManagerConfig:
     database_url: str
     async_database_url: str
     static_definitions_directory: str
+    static_definitions_jobs_selector: t.Optional[str]
     work_items_per_worker: int
 
 

--- a/src/saturn_engine/default_config.py
+++ b/src/saturn_engine/default_config.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import os
 
 from .config import Env
@@ -50,6 +52,9 @@ class config(SaturnConfig):
         )
         static_definitions_directory: str = os.environ.get(
             "SATURN_STATIC_DEFINITIONS_DIR", "/opt/saturn/definitions"
+        )
+        static_definitions_jobs_selector: t.Optional[str] = os.environ.get(
+            "SATURN_STATIC_DEFINITIONS_JOBS_SELECTOR"
         )
         work_items_per_worker = 10
 

--- a/src/saturn_engine/worker_manager/config/declarative.py
+++ b/src/saturn_engine/worker_manager/config/declarative.py
@@ -1,5 +1,7 @@
 from typing import DefaultDict
 
+import dataclasses
+import re
 from collections import defaultdict
 
 from saturn_engine.utils.declarative_config import UncompiledObject
@@ -83,3 +85,16 @@ def load_definitions_from_str(definitions: str) -> StaticDefinitions:
 
 def load_definitions_from_path(config_dir: str) -> StaticDefinitions:
     return compile_static_definitions(load_uncompiled_objects_from_path(config_dir))
+
+
+def filter_with_jobs_selector(
+    *, selector: str, definitions: StaticDefinitions
+) -> StaticDefinitions:
+    pattern = re.compile(selector)
+    jobs = {name: job for name, job in definitions.jobs.items() if pattern.search(name)}
+    job_definitions = {
+        name: job
+        for name, job in definitions.job_definitions.items()
+        if pattern.search(name)
+    }
+    return dataclasses.replace(definitions, jobs=jobs, job_definitions=job_definitions)

--- a/src/saturn_engine/worker_manager/context.py
+++ b/src/saturn_engine/worker_manager/context.py
@@ -1,6 +1,7 @@
 from functools import cached_property
 
 from saturn_engine.config import WorkerManagerConfig
+from saturn_engine.worker_manager.config.declarative import filter_with_jobs_selector
 from saturn_engine.worker_manager.config.declarative import load_definitions_from_path
 
 from .config.static_definitions import StaticDefinitions
@@ -24,4 +25,12 @@ class WorkerManagerContext:
         - Jobs
         - JobDefinitions
         """
-        return load_definitions_from_path(self.config.static_definitions_directory)
+        definitions = load_definitions_from_path(
+            self.config.static_definitions_directory
+        )
+        if self.config.static_definitions_jobs_selector:
+            definitions = filter_with_jobs_selector(
+                definitions=definitions,
+                selector=self.config.static_definitions_jobs_selector,
+            )
+        return definitions

--- a/tests/worker_manager/config/test_declarative.py
+++ b/tests/worker_manager/config/test_declarative.py
@@ -6,8 +6,10 @@ from saturn_engine.core.api import InventoryItem
 from saturn_engine.core.api import JobDefinition
 from saturn_engine.core.api import ResourceItem
 from saturn_engine.core.api import TopicItem
+from saturn_engine.worker_manager.config.declarative import filter_with_jobs_selector
 from saturn_engine.worker_manager.config.declarative import load_definitions_from_path
 from saturn_engine.worker_manager.config.declarative import load_definitions_from_str
+from saturn_engine.worker_manager.config.static_definitions import StaticDefinitions
 
 
 def test_load_definitions_from_path_simple() -> None:
@@ -310,3 +312,92 @@ spec:
         match="SaturnTopic/test-topic already exists",
     ):
         load_definitions_from_str(definitions)
+
+
+def test_filter_with_jobs_selector() -> None:
+    job_definition_str: str = """
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnInventory
+metadata:
+  name: test-inventory
+spec:
+  type: testtype
+---
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnJob
+metadata:
+  name: test-1-job
+spec:
+  input:
+    inventory: test-inventory
+  pipeline:
+    name: something.saturn.pipelines.aa.bb
+---
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnJob
+metadata:
+  name: test-2-job
+spec:
+  input:
+    inventory: test-inventory
+  pipeline:
+    name: something.saturn.pipelines.aa.bb.cc
+---
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnJobDefinition
+metadata:
+  name: test-1-job-definition
+spec:
+  minimalInterval: "@weekly"
+  template:
+    input:
+      inventory: test-inventory
+    pipeline:
+      name: something.saturn.pipelines.aa.bb
+---
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnJobDefinition
+metadata:
+  name: test-2-job-definition
+spec:
+  minimalInterval: "@weekly"
+  template:
+    input:
+      inventory: test-inventory
+    pipeline:
+      name: something.saturn.pipelines.aa.bb
+"""
+
+    def names(definitions: StaticDefinitions) -> dict[str, set[str]]:
+        return {
+            "jobs": set(definitions.jobs.keys()),
+            "job_definitions": set(definitions.job_definitions.keys()),
+        }
+
+    static_definitions = load_definitions_from_str(job_definition_str)
+    assert names(
+        filter_with_jobs_selector(definitions=static_definitions, selector="test-1-")
+    ) == {"jobs": {"test-1-job"}, "job_definitions": {"test-1-job-definition"}}
+
+    assert names(
+        filter_with_jobs_selector(
+            definitions=static_definitions, selector="test-.-job-definition"
+        )
+    ) == {
+        "jobs": set(),
+        "job_definitions": {"test-1-job-definition", "test-2-job-definition"},
+    }
+
+    assert names(
+        filter_with_jobs_selector(definitions=static_definitions, selector="foobar")
+    ) == {
+        "jobs": set(),
+        "job_definitions": set(),
+    }
+
+    assert names(
+        filter_with_jobs_selector(definitions=static_definitions, selector=".*")
+    ) == {
+        "jobs": {"test-1-job", "test-2-job"},
+        "job_definitions": {"test-1-job-definition", "test-2-job-definition"},
+    }


### PR DESCRIPTION
Small life improvement, allows to load a single topology file instead of whole directory. Can be useful to test self-contained pipelines. A more useful followup would probably to have a `static_definitions_job_selector` config that would allow to filter for a subset of jobs.