### PR TITLE
Set name to all create_task calls

### DIFF
--- a/src/saturn_engine/utils/log.py
+++ b/src/saturn_engine/utils/log.py
@@ -8,6 +8,8 @@ T = TypeVar("T")
 
 
 def getLogger(module: str, klass: Union[Type[T], T]) -> logging.Logger:
+    if module.startswith("saturn_engine."):
+        module = "saturn." + module[14:]
     if not isinstance(klass, type):
         klass = klass.__class__
     return logging.getLogger(f"{module}.{klass.__name__}")

--- a/src/saturn_engine/worker/executable_message.py
+++ b/src/saturn_engine/worker/executable_message.py
@@ -53,3 +53,6 @@ class ExecutableMessage:
 
         for resource_used in resources_used:
             self.resources[resource_used.type].release_later(resource_used.release_at)
+
+    def __str__(self) -> str:
+        return self.message.message.id

--- a/src/saturn_engine/worker/resources_manager.py
+++ b/src/saturn_engine/worker/resources_manager.py
@@ -32,7 +32,10 @@ class ResourceContext:
             return
 
         if self.release_at:
-            asyncio.create_task(self._delayed_release(self.resource))
+            asyncio.create_task(
+                self._delayed_release(self.resource),
+                name=f"delayed-release({self.resource.name})",
+            )
         else:
             await self.manager.release(self.resource)
 

--- a/src/saturn_engine/worker/runner.py
+++ b/src/saturn_engine/worker/runner.py
@@ -23,7 +23,7 @@ def main() -> None:
     logger = logging.getLogger(__name__)
 
     loop = asyncio.get_event_loop()
-    loop.run_until_complete(async_main())
+    asyncio.run(async_main())
     if tasks := asyncio.all_tasks(loop):
         logger.error("Leftover tasks: %s", tasks)
 

--- a/src/saturn_engine/worker/scheduler.py
+++ b/src/saturn_engine/worker/scheduler.py
@@ -79,7 +79,10 @@ class Scheduler(Generic[T]):
     async def run(self) -> AsyncIterator[T]:
         while True:
             done = await self.tasks_group.wait()
-            self.logger.debug("task ready", extra={"data": {"tasks": str(done)}})
+            self.logger.debug(
+                "task ready",
+                extra={"data": {"tasks": ",".join(t.get_name() for t in done)}},
+            )
 
             for task in sorted(done, key=self.task_order):
                 async for item in self.process_task(task):

--- a/src/saturn_engine/worker/services/metrics/memory.py
+++ b/src/saturn_engine/worker/services/metrics/memory.py
@@ -20,7 +20,9 @@ class MemoryMetrics(BaseMetricsService[BaseServices, None]):
         self.logger = logging.getLogger("saturn.metrics")
         self.counters: dict[str, int] = defaultdict(int)
         self.timings: dict[str, float] = defaultdict(float)
-        self.printer_task = asyncio.create_task(self.print_metrics())
+        self.printer_task = asyncio.create_task(
+            self.print_metrics(), name="print-metrics"
+        )
 
     async def close(self) -> None:
         self.printer_task.cancel()

--- a/src/saturn_engine/worker/task_manager.py
+++ b/src/saturn_engine/worker/task_manager.py
@@ -1,4 +1,4 @@
-from typing import Union
+import typing as t
 
 import asyncio
 from collections.abc import Coroutine
@@ -12,9 +12,11 @@ class TaskManager:
         self.logger = getLogger(__name__, self)
         self.tasks = TasksGroup()
 
-    def add(self, task: Union[asyncio.Task, Coroutine]) -> asyncio.Task:
+    def add(
+        self, task: t.Union[asyncio.Task, Coroutine], name: t.Optional[str] = None
+    ) -> asyncio.Task:
         if isinstance(task, Coroutine):
-            task = asyncio.create_task(task)
+            task = asyncio.create_task(task, name=name)
         if not isinstance(task, asyncio.Task):
             raise ValueError("Expected asyncio.Task or Coroutine")
         self.tasks.add(task)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -63,6 +63,7 @@ def test_get_own_attr() -> None:
 @pytest.mark.asyncio
 async def test_delayed_throttle() -> None:
     mock = AsyncMock()
+    mock.__qualname__ = "mock"
     throttle = DelayedThrottle(mock, delay=1.0)
     await throttle(1, a=2)
     await asyncio.sleep(0.9)


### PR DESCRIPTION
Also:
 * Add an helper to list all async task (Useful when attaching to process through remote pdb
 * Ensure all logger starts with `saturn.`. Our current prod config is missing a bunch of logs right now.