### PR TITLE
executor: Define concurrency only in Executor class

### DIFF
--- a/src/saturn_engine/worker/executors/ray.py
+++ b/src/saturn_engine/worker/executors/ray.py
@@ -51,6 +51,11 @@ class ExecutorSession:
             },
         )
 
+    @staticmethod
+    def concurrency(services: Services) -> int:
+        config = services.config.c.ray
+        return config.executor_actor_concurrency * config.executor_actor_count
+
     def close(self) -> None:
         pass
 
@@ -60,6 +65,10 @@ class RayExecutor(Executor):
         self.logger = getLogger(__name__, self)
         self.services = services
         self._session: t.Optional[ExecutorSession] = None
+
+    @property
+    def concurrency(self) -> int:
+        return ExecutorSession.concurrency(self.services)
 
     @contextlib.contextmanager
     def session(self) -> Iterator[ExecutorSession]:

--- a/tests/worker/conftest.py
+++ b/tests/worker/conftest.py
@@ -88,14 +88,12 @@ async def executor_manager_maker(
 
         def maker(
             executor: Optional[Executor] = None,
-            concurrency: int = 5,
             services: Services = services_manager.services,
         ) -> ExecutorManager:
             executor = executor or executor_maker(services_manager.services)
             manager = ExecutorManager(
                 resources_manager=resources_manager,
                 executor=executor,
-                concurrency=concurrency,
                 services=services,
             )
             manager.start()

--- a/tests/worker/test_broker.py
+++ b/tests/worker/test_broker.py
@@ -20,6 +20,8 @@ from tests.worker.conftest import FakeResource
 
 
 class FakeExecutor(Executor):
+    concurrency = 5
+
     def __init__(self) -> None:
         self.done_event = asyncio.Event()
 

--- a/tests/worker/test_executor.py
+++ b/tests/worker/test_executor.py
@@ -22,6 +22,8 @@ from tests.worker.conftest import FakeResource
 
 
 class FakeExecutor(Executor):
+    concurrency = 1
+
     def __init__(self) -> None:
         self.execute_semaphore = asyncio.Semaphore(0)
         self.processing = 0
@@ -48,6 +50,7 @@ async def test_base_executor(
     executor_manager_maker: Callable[..., ExecutorManager],
 ) -> None:
     executor = FakeExecutor()
+    executor.concurrency = 5
     executor_manager = executor_manager_maker(executor=executor)
 
     async with event_loop.until_idle():
@@ -74,7 +77,7 @@ async def test_executor_wait_resources_and_queue(
     executor_manager_maker: Callable[..., ExecutorManager],
 ) -> None:
     executor = FakeExecutor()
-    executor_manager = executor_manager_maker(executor=executor, concurrency=1)
+    executor_manager = executor_manager_maker(executor=executor)
     await executor_manager.resources_manager.add(
         ResourceData(name="r1", type="FakeResource", data={})
     )
@@ -130,7 +133,7 @@ async def test_executor_wait_pusblish_and_queue(
     executor_manager_maker: Callable[..., ExecutorManager],
 ) -> None:
     executor = FakeExecutor()
-    executor_manager = executor_manager_maker(executor=executor, concurrency=1)
+    executor_manager = executor_manager_maker(executor=executor)
     await executor_manager.resources_manager.add(
         ResourceData(name="r1", type="FakeResource", data={})
     )


### PR DESCRIPTION
@aviau | @KevGoDev 

Since there's no point in having a different concurrency value in `ExecutorManager` and the actual concurrency of the `Executor`, I make `concurrency` an attribute of `Executor` that is implementation dependant. This way, we can just increase the ray settings and the executor manager will increase it's executing queue count.