### PR TITLE
Rabbitmq: Make rabbitmq more reliable

### DIFF
--- a/src/saturn_engine/utils/asyncutils.py
+++ b/src/saturn_engine/utils/asyncutils.py
@@ -1,21 +1,18 @@
-from typing import Any
-from typing import Callable
-from typing import Generic
-from typing import Optional
-from typing import TypeVar
+import typing as t
 
 import asyncio
 import contextlib
 from collections.abc import AsyncGenerator
 from collections.abc import AsyncIterator
 from collections.abc import Awaitable
+from collections.abc import Coroutine
 from collections.abc import Iterable
 
 from saturn_engine.utils.log import getLogger
 
-T = TypeVar("T")
+T = t.TypeVar("T")
 
-AsyncFNone = TypeVar("AsyncFNone", bound=Callable[..., Awaitable[None]])
+AsyncFNone = t.TypeVar("AsyncFNone", bound=t.Callable[..., Awaitable[None]])
 
 
 async def aiter2agen(iterator: AsyncIterator[T]) -> AsyncGenerator[T, None]:
@@ -28,7 +25,7 @@ async def aiter2agen(iterator: AsyncIterator[T]) -> AsyncGenerator[T, None]:
 
 class TasksGroup:
     def __init__(
-        self, tasks: Iterable[asyncio.Task] = (), *, name: Optional[str] = None
+        self, tasks: Iterable[asyncio.Task] = (), *, name: t.Optional[str] = None
     ) -> None:
         self.logger = getLogger(__name__, self)
         self.tasks = set(tasks)
@@ -40,10 +37,18 @@ class TasksGroup:
 
     def add(self, task: asyncio.Task) -> None:
         self.tasks.add(task)
-        self.updated.set()
+        self.notify()
+
+    def create_task(self, coroutine: Coroutine, **kwargs: t.Any) -> asyncio.Task:
+        task = asyncio.create_task(coroutine, **kwargs)
+        self.add(task)
+        return task
 
     def remove(self, task: asyncio.Task) -> None:
         self.tasks.discard(task)
+        self.notify()
+
+    def notify(self) -> None:
         self.updated.set()
 
     async def wait(self) -> set[asyncio.Task]:
@@ -56,39 +61,95 @@ class TasksGroup:
             done.remove(self.updated_task)
             self.updated_task = asyncio.create_task(self.updated.wait(), name=self.name)
 
+        self.tasks.difference_update(done)
+
         return done
 
-    async def close(self) -> None:
+    async def close(self, timeout: t.Optional[float] = None) -> None:
+        # Cancel the update event task.
         self.updated_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await self.updated_task
 
+        if not self.tasks:
+            return
+
+        # Give the chance of all task to terminate within 'timeout'.
+        if timeout:
+            done, _ = await asyncio.wait(self.tasks, timeout=timeout)
+
+        # Cancel all remaining tasks.
         for task in self.tasks:
-            task.cancel()
-        tasks_results = await asyncio.gather(*self.tasks, return_exceptions=True)
-        for result in tasks_results:
-            if isinstance(result, Exception):
+            if not task.done():
+                task.cancel()
+
+        # Collect results to log errors.
+        done, pending = await asyncio.wait(self.tasks, timeout=timeout)
+        for task in done:
+            if not task.cancelled() and isinstance(task.exception(), Exception):
                 self.logger.error(
-                    "Task '%s' cancelled with error", task, exc_info=result
+                    "Task '%s' cancelled with error", task, exc_info=task.exception()
                 )
+        for task in pending:
+            self.logger.error("Task '%s' won't complete", task)
+
         self.tasks.clear()
 
     def all(self) -> set[asyncio.Task]:
         return self.tasks
 
 
-class DelayedThrottle(Generic[AsyncFNone]):
+class TasksGroupRunner(TasksGroup):
+    def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._runner_task: t.Optional[asyncio.Task]
+        self.is_running = False
+
+    def start(self) -> asyncio.Task:
+        if self.is_running:
+            raise RuntimeError("task group is already running")
+        self.is_running = True
+        self._runner_task = asyncio.create_task(self.run())
+        return self._runner_task
+
+    async def stop(self) -> None:
+        self.is_running = False
+        self.notify()
+
+    async def close(self, timeout: t.Optional[float] = None) -> None:
+        if self.is_running is False:
+            return
+
+        # Stop the runner.
+        await self.stop()
+        # Wait for the running task to complete.
+        if self._runner_task:
+            await self._runner_task
+        # Clean the tasks.
+        await super().close(timeout=timeout)
+
+    async def run(self) -> None:
+        while self.is_running:
+            done = await self.wait()
+            for task in done:
+                if not task.cancelled() and isinstance(task.exception(), Exception):
+                    self.logger.error(
+                        "Task '%s' failed", task, exc_info=task.exception()
+                    )
+
+
+class DelayedThrottle(t.Generic[AsyncFNone]):
     __call__: AsyncFNone
 
     def __init__(self, func: AsyncFNone, *, delay: float) -> None:
         self.func = func
         self.delay = delay
-        self.delayed_task: Optional[asyncio.Task] = None
+        self.delayed_task: t.Optional[asyncio.Task] = None
         self.delayed_lock = asyncio.Lock()
-        self.delayed_args: tuple[Any, ...] = ()
-        self.delayed_kwargs: dict[str, Any] = {}
+        self.delayed_args: tuple[t.Any, ...] = ()
+        self.delayed_kwargs: dict[str, t.Any] = {}
 
-    async def __call__(self, *args: Any, **kwargs: Any) -> None:  # type: ignore
+    async def __call__(self, *args: t.Any, **kwargs: t.Any) -> None:  # type: ignore
         async with self.delayed_lock:
             self.delayed_args = args
             self.delayed_kwargs = kwargs
@@ -119,7 +180,7 @@ class DelayedThrottle(Generic[AsyncFNone]):
             self.delayed_task = None
 
 
-def print_tasks_summary(loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
+def print_tasks_summary(loop: t.Optional[asyncio.AbstractEventLoop] = None) -> None:
     loop = loop or asyncio.get_running_loop()
     tasks = list(asyncio.all_tasks(loop))
     tasks.sort(key=lambda t: t.get_name())
@@ -129,3 +190,126 @@ def print_tasks_summary(loop: Optional[asyncio.AbstractEventLoop] = None) -> Non
         if stack:
             frame = stack[-1]
             print(f"  {frame.f_code.co_name}:{frame.f_lineno}")
+
+
+class CachedProperty(t.Generic[T]):
+    def __init__(self, getter: t.Callable[[t.Any], Awaitable[T]]) -> None:
+        self.__wrapped__ = getter
+        self._name = getter.__name__
+        self.__doc__ = getter.__doc__
+
+    def __set_name__(self, owner: t.Any, name: str) -> None:
+        # Check whether we can store anything on the instance
+        # Note that this is a failsafe, and might fail ugly.
+        # People who are clever enough to avoid this heuristic
+        # should also be clever enough to know the why and what.
+        if not any("__dict__" in dir(cls) for cls in owner.__mro__):
+            raise TypeError(
+                "'cached_property' requires '__dict__' "
+                f"on {owner.__name__!r} to store {name}"
+            )
+        self._name = name
+
+    def __get__(self, instance: t.Any, owner: t.Any) -> t.Any:
+        if instance is None:
+            return self
+        return self._get_attribute(instance)
+
+    async def _get_attribute(self, instance: t.Any) -> T:
+        value = instance.__dict__.get(self._name)
+        if value is None:
+            task = asyncio.create_task(self.__wrapped__(instance))
+            instance.__dict__[self._name] = task
+            try:
+                value = await task
+            except BaseException:
+                del instance.__dict__[self._name]
+                raise
+
+            # Once the task is complete, replace with a future to only hold
+            # the value and drop the task.
+            future: asyncio.Future[T] = asyncio.Future()
+            future.set_result(value)
+            instance.__dict__[self._name] = future
+            return value
+
+        return await value
+
+
+cached_property = CachedProperty
+
+
+class WouldBlock(Exception):
+    pass
+
+
+class FakeSemaphore(contextlib.AbstractAsyncContextManager):
+    def locked(self) -> bool:
+        return False
+
+
+class SharedLock:
+    """Like a lock, but bind a lock to a reservation.
+    * A reservation can only be made if there's no active lock.
+    * A reservation can lock, blocking any new reservation or reservation
+      locking.
+    * Once reservation is locked, this reservation can be locked many time
+      without blocking.
+    """
+
+    def __init__(self, *, max_reservations: int = 0):
+        self._lock = asyncio.Lock()
+        self._locker: t.Optional[object] = None
+        if max_reservations:
+            self._reservations_lock = asyncio.Semaphore(max_reservations)
+        else:
+            self._reservations_lock = t.cast(asyncio.Semaphore, FakeSemaphore())
+
+    @contextlib.asynccontextmanager
+    async def reserve(self) -> AsyncIterator["SharedLockReservation"]:
+        async with self._reservations_lock:
+            async with self._lock:
+                reservation = SharedLockReservation(lock=self)
+
+            try:
+                yield reservation
+            finally:
+                reservation.release()
+
+    def locked(self) -> bool:
+        return self._lock.locked()
+
+    def locked_reservations(self) -> bool:
+        return self.locked() or self._reservations_lock.locked()
+
+    async def _acquire(self, reservation: object) -> None:
+        if self._locker is reservation:
+            return
+
+        await self._lock.acquire()
+        self._locker = reservation
+
+    def _release(self, reservation: object) -> None:
+        if self._locker is not reservation:
+            return
+
+        self._locker = None
+        self._lock.release()
+
+
+class SharedLockReservation:
+    def __init__(self, *, lock: SharedLock) -> None:
+        self._lock = lock
+
+    async def acquire(self) -> None:
+        """Lock the queue, blocking any other reservation or lock itself if the
+        queue is already locked.
+        Return True if the lock don't block itself, False otherwise.
+        """
+        await self._lock._acquire(self)
+
+    def locked(self) -> bool:
+        return self._lock._locker is self
+
+    def release(self) -> None:
+        self._lock._release(self)

--- a/src/saturn_engine/worker/broker.py
+++ b/src/saturn_engine/worker/broker.py
@@ -126,8 +126,8 @@ class Broker:
                 await self.resources_manager.remove(resource)
 
     async def close(self) -> None:
-        await self.scheduler.close()
         await self.executor.close()
+        await self.scheduler.close()
         await self.services_manager.close()
 
     def stop(self) -> None:

--- a/src/saturn_engine/worker/scheduler.py
+++ b/src/saturn_engine/worker/scheduler.py
@@ -91,7 +91,6 @@ class Scheduler(Generic[T]):
     async def process_task(self, task: asyncio.Task) -> AsyncIterator[T]:
         item = self.tasks[task]
         del self.tasks[task]
-        self.tasks_group.remove(task)
 
         try:
             # Even if the task finished, if the item was removed we

--- a/src/saturn_engine/worker/services/loggers/console_logging.py
+++ b/src/saturn_engine/worker/services/loggers/console_logging.py
@@ -117,6 +117,17 @@ def setup_logging(formatter: t.Optional[dict[str, t.Any]] = None) -> None:
                 },
             },
             "root": {"handlers": ["default"], "level": "DEBUG"},
-            "loggers": {"aio_pika": {"handlers": ["default"], "level": "INFO"}},
+            "loggers": {
+                "aio_pika": {
+                    "handlers": ["default"],
+                    "level": "INFO",
+                    "propagate": False,
+                },
+                "aiormq": {
+                    "handlers": ["default"],
+                    "level": "INFO",
+                    "propagate": False,
+                },
+            },
         }
     )

--- a/src/saturn_engine/worker/services/rabbitmq.py
+++ b/src/saturn_engine/worker/services/rabbitmq.py
@@ -1,6 +1,7 @@
 import aio_pika
 import aio_pika.abc
-import asyncstdlib as alib
+
+from saturn_engine.utils.asyncutils import cached_property
 
 from . import MinimalService
 
@@ -8,8 +9,8 @@ from . import MinimalService
 class RabbitMQService(MinimalService):
     name = "rabbitmq"
 
-    @alib.cached_property
-    async def connection(self) -> aio_pika.abc.AbstractConnection:
+    @cached_property
+    async def connection(self) -> aio_pika.abc.AbstractRobustConnection:
         return await aio_pika.connect_robust(self.services.config.c.rabbitmq.url)
 
     async def close(self) -> None:

--- a/src/saturn_engine/worker/task_manager.py
+++ b/src/saturn_engine/worker/task_manager.py
@@ -40,7 +40,6 @@ class TaskManager:
             self.logger.warning(
                 "Task '%s' completed with result: %s", task, task.result()
             )
-        self.tasks.remove(task)
 
     async def close(self) -> None:
         await self.tasks.close()

--- a/src/saturn_engine/worker/topics/rabbitmq.py
+++ b/src/saturn_engine/worker/topics/rabbitmq.py
@@ -14,6 +14,8 @@ import aio_pika.abc
 import aio_pika.exceptions
 
 from saturn_engine.core import TopicMessage
+from saturn_engine.utils.asyncutils import SharedLock
+from saturn_engine.utils.asyncutils import cached_property
 from saturn_engine.utils.log import getLogger
 from saturn_engine.utils.options import asdict
 from saturn_engine.utils.options import fromdict
@@ -45,8 +47,8 @@ class RabbitMQTopic(Topic):
         self.options = options
         self.services = services.cast(RabbitMQTopic.TopicServices)
         self.exit_stack = contextlib.AsyncExitStack()
-        self._channel: t.Optional[aio_pika.abc.AbstractChannel] = None
         self._queue: t.Optional[aio_pika.abc.AbstractQueue] = None
+        self._publish_lock = SharedLock(max_reservations=8)
 
     async def run(self) -> AsyncGenerator[t.AsyncContextManager[TopicMessage], None]:
         self.logger.info("Starting queue %s", self.options.queue_name)
@@ -54,13 +56,13 @@ class RabbitMQTopic(Topic):
         while True:
             try:
                 self.logger.info("Processing queue %s", self.options.queue_name)
-                async with (await self.get_queue()).iterator() as queue_iter:
+                queue = await self.queue
+                async with queue.iterator() as queue_iter:
                     async for message in queue_iter:
                         attempt = 0
                         yield self.message_context(message)
             except Exception:
                 self.logger.exception("Failed to consume")
-                await self.reset()
                 await self.backoff_sleep(attempt)
                 attempt += 1
             else:
@@ -72,58 +74,66 @@ class RabbitMQTopic(Topic):
         wait: bool,
     ) -> bool:
         attempt = 0
-        while True:
-            try:
-                await self.get_queue()  # Ensure the queue is created.
-                exchange = (await self.get_channel()).default_exchange
-                if exchange is None:
-                    raise ValueError("Channel has no exchange")
-                await exchange.publish(
-                    aio_pika.Message(
-                        body=json.dumps(asdict(message)).encode(),
-                        delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
-                    ),
-                    routing_key=self.options.queue_name,
-                )
-                return True
-            except (aio_pika.exceptions.ChannelInvalidStateError, ConnectionError):
-                self.logger.exception("Failed to publish")
 
-                # The channel is broken. Let's create a new one.
-                await self.reset()
+        # Wait for the queue to unblock.
+        if not wait and self._publish_lock.locked_reservations():
+            return False
 
-                # If we are non blocking, we try again only once to deal with
-                # possible connection reset that are quick to retry.
-                if wait or attempt == 0:
-                    await self.backoff_sleep(attempt)
-                else:
-                    # otherwise we reraise the failure.
-                    raise
-                attempt += 1
+        async with self._publish_lock.reserve() as reservation:
+            while True:
+                try:
+                    await self.ensure_queue()  # Ensure the queue is created.
+                    channel = await self.channel
+                    exchange = channel.default_exchange
+                    if exchange is None:
+                        raise ValueError("Channel has no exchange")
+                    await exchange.publish(
+                        aio_pika.Message(
+                            body=json.dumps(asdict(message)).encode(),
+                            delivery_mode=aio_pika.DeliveryMode.PERSISTENT,
+                        ),
+                        routing_key=self.options.queue_name,
+                    )
+                    return True
+                except aio_pika.exceptions.DeliveryError as e:
+                    # Only handle Nack
+                    if e.frame.name != "Basic.Nack":
+                        raise
 
-            except aio_pika.exceptions.DeliveryError as e:
-                # Only handle Nack
-                if e.frame.name != "Basic.Nack":
-                    raise
+                    if not wait:
+                        return False
 
-                # If we are non blocking, we stop trying.
-                if not wait:
-                    return False
+                    # If the lock is being help by another task, we can assume
+                    # that once the control is being yielded to this task it
+                    # will be after successfully publishing a message, therefor
+                    # there's no need to sleep.
+                    has_locked = reservation.locked() or not self._publish_lock.locked()
+                    await reservation.acquire()
+                    if has_locked:
+                        await asyncio.sleep(self.RETRY_PUBLISH_DELAY.total_seconds())
+                    attempt = 0
+                except Exception:
+                    self.logger.exception("Failed to publish")
+                    if not wait:
+                        raise
 
-                # Otherwise, take a small break and try again.
-                await asyncio.sleep(self.RETRY_PUBLISH_DELAY.total_seconds())
-                attempt = 0
+                    # If the lock is being help by another task, we can assume
+                    # that once the control is being yielded to this task it
+                    # will be after successfully publishing a message, therefor
+                    # there's no need to sleep.
+                    has_locked = reservation.locked() or not self._publish_lock.locked()
+                    await reservation.acquire()
+                    if has_locked:
+                        await self.backoff_sleep(attempt)
+                        attempt += 1
+
+            return False
 
     async def backoff_sleep(self, attempt: int) -> None:
         retry_delay = self.FAILURE_RETRY_BACKOFFS[-1]
         if attempt < len(self.FAILURE_RETRY_BACKOFFS):
             retry_delay = self.FAILURE_RETRY_BACKOFFS[attempt]
         await asyncio.sleep(retry_delay.total_seconds())
-
-    async def reset(self) -> None:
-        await self.close()
-        self._channel = None
-        self._queue = None
 
     @asynccontextmanager
     async def message_context(
@@ -132,34 +142,45 @@ class RabbitMQTopic(Topic):
         async with message.process():
             yield fromdict(json.loads(message.body.decode()), TopicMessage)
 
-    async def get_channel(self) -> aio_pika.abc.AbstractChannel:
-        if self._channel is None:
-            connection: aio_pika.Connection = await self.services.rabbitmq.connection
-            channel = await self.exit_stack.enter_async_context(
-                connection.channel(on_return_raises=True)
-            )
+    @cached_property
+    async def channel(self) -> aio_pika.abc.AbstractChannel:
+        connection = await self.services.rabbitmq.connection
+        channel = await self.exit_stack.enter_async_context(
+            connection.channel(on_return_raises=True)
+        )
 
-            if self.options.prefetch_count is not None:
-                await channel.set_qos(prefetch_count=self.options.prefetch_count)
-            self._channel = channel
+        if self.options.prefetch_count is not None:
+            await channel.set_qos(prefetch_count=self.options.prefetch_count)
+        channel.close_callbacks.add(self.channel_closed)
+        return channel
 
-        return self._channel
+    def channel_closed(
+        self, channel: aio_pika.abc.AbstractChannel, reason: t.Optional[Exception]
+    ) -> None:
+        if isinstance(reason, BaseException):
+            self.logger.error("Channel closed", exc_info=reason)
+        elif reason:
+            self.logger.error("Channel closed: %s", reason)
 
-    async def get_queue(self) -> aio_pika.abc.AbstractQueue:
-        if self._queue is None:
-            arguments: dict[str, t.Any] = {}
-            if self.options.max_length:
-                arguments["x-max-length"] = self.options.max_length
-                arguments["x-overflow"] = "reject-publish"
+    @cached_property
+    async def queue(self) -> aio_pika.abc.AbstractQueue:
+        arguments: dict[str, t.Any] = {}
+        if self.options.max_length:
+            arguments["x-max-length"] = self.options.max_length
+            arguments["x-overflow"] = "reject-publish"
 
-            self._queue = await (await self.get_channel()).declare_queue(
-                self.options.queue_name,
-                auto_delete=self.options.auto_delete,
-                durable=self.options.durable,
-                arguments=arguments,
-            )
+        channel = await self.channel
+        queue = await channel.declare_queue(
+            self.options.queue_name,
+            auto_delete=self.options.auto_delete,
+            durable=self.options.durable,
+            arguments=arguments,
+        )
 
-        return self._queue
+        return queue
+
+    async def ensure_queue(self) -> aio_pika.abc.AbstractQueue:
+        return await self.queue
 
     async def close(self) -> None:
         await self.exit_stack.aclose()

--- a/tests/utils/tcp_proxy.py
+++ b/tests/utils/tcp_proxy.py
@@ -1,0 +1,76 @@
+import typing as t
+
+import asyncio
+
+
+# Adapted from https://github.com/aio-libs/aiopg/blob/master/tests/conftest.py#L416
+class TcpProxy:
+    """
+    TCP proxy. Allows simulating connection breaks in tests.
+    """
+
+    MAX_BYTES = 1024
+
+    def __init__(
+        self,
+        *,
+        src_host: str = "127.0.0.1",
+        src_port: int,
+        dst_host: str = "127.0.0.1",
+        dst_port: int,
+    ) -> None:
+        self.src_host = src_host
+        self.src_port = src_port
+        self.dst_host = dst_host
+        self.dst_port = dst_port
+        self.connections: set[t.Any] = set()
+        self.server: t.Optional[asyncio.AbstractServer] = None
+
+    async def start(self) -> None:
+        self.server = await asyncio.start_server(
+            self._handle_client,
+            host=self.src_host,
+            port=self.src_port,
+        )
+
+    async def disconnect(self) -> None:
+        while self.connections:
+            writer = self.connections.pop()
+            writer.close()
+            if hasattr(writer, "wait_closed"):
+                await writer.wait_closed()
+
+    @staticmethod
+    async def _pipe(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            while not reader.at_eof():
+                bytes_read = await reader.read(TcpProxy.MAX_BYTES)
+                writer.write(bytes_read)
+                await writer.drain()
+        finally:
+            writer.close()
+
+    async def _handle_client(
+        self,
+        client_reader: asyncio.StreamReader,
+        client_writer: asyncio.StreamWriter,
+    ) -> None:
+        server_reader, server_writer = await asyncio.open_connection(
+            host=self.dst_host, port=self.dst_port
+        )
+
+        self.connections.add(server_writer)
+        self.connections.add(client_writer)
+
+        await asyncio.wait(
+            [
+                asyncio.ensure_future(self._pipe(server_reader, client_writer)),
+                asyncio.ensure_future(self._pipe(client_reader, server_writer)),
+            ]
+        )
+
+    async def close(self) -> None:
+        await self.disconnect()
+        if self.server:
+            self.server.close()
+            await self.server.wait_closed()

--- a/tests/worker/conftest.py
+++ b/tests/worker/conftest.py
@@ -31,6 +31,7 @@ from saturn_engine.worker.services.rabbitmq import RabbitMQService
 from saturn_engine.worker.topics import Topic
 from saturn_engine.worker.topics.memory import reset as reset_memory_queues
 from saturn_engine.worker.work_manager import WorkManager
+from tests.utils import TimeForwardLoop
 
 
 @pytest.fixture
@@ -168,7 +169,10 @@ def fake_resource_class() -> str:
 
 
 @pytest.fixture
-async def rabbitmq_service(services_manager: ServicesManager) -> RabbitMQService:
+async def rabbitmq_service(
+    event_loop: TimeForwardLoop, services_manager: ServicesManager
+) -> RabbitMQService:
+    event_loop.forward_time = False
     services_manager._load_service(RabbitMQService)
     _rabbitmq_service = services_manager.services.rabbitmq
     try:


### PR DESCRIPTION
@aviau @KevGoDev 

Sorry for the big PR, got carried away, fixing small issues after big issues after small issues.

Overall:

 * Robust management of connection/channel. I've been doing a lot of test on my machine, killing rabbitmq, etc. Seems to be working well. Fixed a few race condition, complicated error handling, maximum concurrency of retries/nack, etc.
 * Added some better cleanup, now the executor try to gracefully clean its pending task. Still not working very well with backpressured task, I have some idea how to cancel these, but that would fit in another PR.
 * Better testing of channel closed and connection dropped.