### PR TITLE
declarative: Add executor to declarative files

### DIFF
--- a/src/saturn_engine/core/api.py
+++ b/src/saturn_engine/core/api.py
@@ -128,7 +128,7 @@ class JobsSyncResponse:
 
 
 @dataclasses.dataclass
-class ExecutorItem:
+class Executor:
     name: str
     type: str
     options: dict[str, Any] = dataclasses.field(default_factory=dict)

--- a/src/saturn_engine/worker/executors/manager.py
+++ b/src/saturn_engine/worker/executors/manager.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from saturn_engine.core.api import ExecutorItem
+from saturn_engine.core import api
 from saturn_engine.utils.asyncutils import TasksGroupRunner
 from saturn_engine.worker.services import Services
 
@@ -28,7 +28,7 @@ class ExecutorsManager:
         # TODO: Executor should be loaded through definitions and
         # `add_executor`.
         self.add_executor(
-            ExecutorItem(
+            api.Executor(
                 name="default",
                 type=services.s.config.c.worker.executor_cls,
             ),
@@ -55,7 +55,7 @@ class ExecutorsManager:
             return
         await executor.remove_schedulable(queue)
 
-    def add_executor(self, executor_definition: ExecutorItem) -> None:
+    def add_executor(self, executor_definition: api.Executor) -> None:
         if executor_definition.name in self.executors:
             raise ValueError("Executor already defined")
 
@@ -90,7 +90,7 @@ class ExecutorWorker:
     @classmethod
     def from_item(
         cls,
-        executor_definition: ExecutorItem,
+        executor_definition: api.Executor,
         *,
         resources_manager: ResourcesManager,
         services: Services,

--- a/src/saturn_engine/worker_manager/config/declarative.py
+++ b/src/saturn_engine/worker_manager/config/declarative.py
@@ -9,6 +9,7 @@ from saturn_engine.utils.declarative_config import load_uncompiled_objects_from_
 from saturn_engine.utils.declarative_config import load_uncompiled_objects_from_str
 from saturn_engine.utils.options import fromdict
 
+from .declarative_executor import Executor
 from .declarative_inventory import Inventory
 from .declarative_job import Job
 from .declarative_job_definition import JobDefinition
@@ -31,6 +32,13 @@ def compile_static_definitions(
         ] = uncompiled_object
 
     definitions: StaticDefinitions = StaticDefinitions()
+
+    for uncompiled_executor in objects_by_kind.pop(
+        "SaturnExecutor",
+        dict(),
+    ).values():
+        executor: Executor = fromdict(uncompiled_executor.data, Executor)
+        definitions.executors[executor.metadata.name] = executor.to_core_object()
 
     for uncompiled_inventory in objects_by_kind.pop(
         "SaturnInventory",

--- a/src/saturn_engine/worker_manager/config/declarative_executor.py
+++ b/src/saturn_engine/worker_manager/config/declarative_executor.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+import dataclasses
+
+from saturn_engine.core import api
+from saturn_engine.utils.declarative_config import BaseObject
+
+
+@dataclasses.dataclass
+class ExecutorSpec:
+    type: str
+    options: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass
+class Executor(BaseObject):
+    spec: ExecutorSpec
+
+    def to_core_object(self) -> api.Executor:
+        return api.Executor(
+            name=self.metadata.name,
+            type=self.spec.type,
+            options=self.spec.options,
+        )

--- a/src/saturn_engine/worker_manager/config/static_definitions.py
+++ b/src/saturn_engine/worker_manager/config/static_definitions.py
@@ -1,6 +1,7 @@
 import dataclasses
 from collections import defaultdict
 
+from saturn_engine.core.api import Executor
 from saturn_engine.core.api import InventoryItem
 from saturn_engine.core.api import JobDefinition
 from saturn_engine.core.api import QueueItem
@@ -10,6 +11,7 @@ from saturn_engine.core.api import TopicItem
 
 @dataclasses.dataclass
 class StaticDefinitions:
+    executors: dict[str, Executor] = dataclasses.field(default_factory=dict)
     inventories: dict[str, InventoryItem] = dataclasses.field(default_factory=dict)
     topics: dict[str, TopicItem] = dataclasses.field(default_factory=dict)
     job_definitions: dict[str, JobDefinition] = dataclasses.field(default_factory=dict)

--- a/tests/worker_manager/config/test_declarative.py
+++ b/tests/worker_manager/config/test_declarative.py
@@ -401,3 +401,21 @@ spec:
         "jobs": {"test-1-job", "test-2-job"},
         "job_definitions": {"test-1-job-definition", "test-2-job-definition"},
     }
+
+
+def test_load_executor() -> None:
+    executor_definition_str = """
+    apiVersion: saturn.flared.io/v1alpha1
+    kind: SaturnExecutor
+    metadata:
+      name: test-executor
+    spec:
+      type: ProcessExecutor
+      options:
+        pool_size: 2
+    """
+
+    static_definitions = load_definitions_from_str(executor_definition_str)
+
+    assert len(static_definitions.executors) == 1
+    assert static_definitions.executors["test-executor"].options["pool_size"] == 2


### PR DESCRIPTION
@KevGoDev | @aviau 

We can now declare Executors in the topology files.

Next: Return these in /sync and use them to create executors.