### PR TITLE
worker-manager: lock API returns jobs executors

### DIFF
--- a/src/saturn_engine/core/api.py
+++ b/src/saturn_engine/core/api.py
@@ -56,9 +56,17 @@ class JobDefinition:
 
 
 @dataclasses.dataclass
+class Executor:
+    name: str
+    type: str
+    options: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass
 class LockResponse:
     items: list[QueueItem]
     resources: list[ResourceItem]
+    executors: list[Executor]
 
 
 @dataclasses.dataclass
@@ -125,10 +133,3 @@ class UpdateResponse:
 @dataclasses.dataclass
 class JobsSyncResponse:
     pass
-
-
-@dataclasses.dataclass
-class Executor:
-    name: str
-    type: str
-    options: dict[str, Any] = dataclasses.field(default_factory=dict)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,52 +83,6 @@ def fake_pipeline_info(fake_pipeline: t.Callable) -> api.PipelineInfo:
     return api.PipelineInfo.from_pipeline(fake_pipeline)
 
 
-@pytest.fixture
-def queue_pipeline_maker(
-    fake_pipeline_info: api.PipelineInfo,
-) -> t.Callable[..., api.QueuePipeline]:
-    def maker() -> api.QueuePipeline:
-        return api.QueuePipeline(info=fake_pipeline_info, args={})
-
-    return maker
-
-
-@pytest.fixture
-def topic_item_maker() -> t.Callable[..., api.TopicItem]:
-    def maker() -> api.TopicItem:
-        return api.TopicItem(name="test", type="test", options={})
-
-    return maker
-
-
-@pytest.fixture
-def queue_item_maker(
-    queue_pipeline_maker: t.Callable[..., api.QueuePipeline],
-    topic_item_maker: t.Callable[..., api.TopicItem],
-) -> t.Callable[..., api.QueueItem]:
-    def maker() -> api.QueueItem:
-        return api.QueueItem(
-            name="test",
-            pipeline=queue_pipeline_maker(),
-            input=topic_item_maker(),
-            output={"default": [topic_item_maker()]},
-        )
-
-    return maker
-
-
-@pytest.fixture
-def job_definition_maker(
-    queue_item_maker: t.Callable[..., api.QueueItem]
-) -> t.Callable[..., api.JobDefinition]:
-    def maker() -> api.JobDefinition:
-        return api.JobDefinition(
-            name="test", template=queue_item_maker(), minimal_interval="@weekly"
-        )
-
-    return maker
-
-
 @pytest.fixture(scope="session")
 def config() -> Config:
     return Config().load_objects([default_config, test_config])

--- a/tests/worker/conftest.py
+++ b/tests/worker/conftest.py
@@ -37,7 +37,9 @@ from tests.utils import TimeForwardLoop
 @pytest.fixture
 def worker_manager_client() -> Mock:
     _worker_manager_client = create_autospec(WorkerManagerClient, instance=True)
-    _worker_manager_client.lock.return_value = LockResponse(items=[], resources=[])
+    _worker_manager_client.lock.return_value = LockResponse(
+        items=[], resources=[], executors=[]
+    )
     return _worker_manager_client
 
 

--- a/tests/worker/test_broker.py
+++ b/tests/worker/test_broker.py
@@ -7,6 +7,7 @@ import pytest
 
 from saturn_engine.config import Config
 from saturn_engine.core import PipelineResults
+from saturn_engine.core import api
 from saturn_engine.core.api import InventoryItem
 from saturn_engine.core.api import LockResponse
 from saturn_engine.core.api import PipelineInfo
@@ -70,6 +71,11 @@ async def test_broker_dummy(
                 name="r1",
                 type="FakeResource",
                 data={"data": "fake"},
+            ),
+        ],
+        executors=[
+            api.Executor(
+                name="e1", type=get_import_name(FakeExecutor), options={"assert": True}
             ),
         ],
     )

--- a/tests/worker_manager/api/test_jobs.py
+++ b/tests/worker_manager/api/test_jobs.py
@@ -155,6 +155,7 @@ def test_jobs_sync(
     static_definitions: StaticDefinitions,
     session: Session,
     frozen_time: FreezeTime,
+    fake_executor: api.Executor,
 ) -> None:
     new_definitions_str: str = """
 apiVersion: saturn.flared.io/v1alpha1
@@ -364,6 +365,7 @@ def test_failed_jobs(
     client: FlaskClient,
     session: Session,
     static_definitions: StaticDefinitions,
+    fake_executor: api.Executor,
     frozen_time: FreezeTime,
 ) -> None:
     # Add a job

--- a/tests/worker_manager/conftest.py
+++ b/tests/worker_manager/conftest.py
@@ -1,5 +1,4 @@
-from typing import Callable
-from typing import Iterator
+import typing as t
 
 import pytest
 from flask.testing import FlaskClient
@@ -13,30 +12,87 @@ from saturn_engine.worker_manager.config.declarative import StaticDefinitions
 
 
 @pytest.fixture
-def session() -> Iterator[Session]:
+def queue_pipeline_maker(
+    fake_pipeline_info: api.PipelineInfo,
+) -> t.Callable[..., api.QueuePipeline]:
+    def maker() -> api.QueuePipeline:
+        return api.QueuePipeline(info=fake_pipeline_info, args={})
+
+    return maker
+
+
+@pytest.fixture
+def topic_item_maker() -> t.Callable[..., api.TopicItem]:
+    def maker() -> api.TopicItem:
+        return api.TopicItem(name="test", type="test", options={})
+
+    return maker
+
+
+@pytest.fixture
+def queue_item_maker(
+    queue_pipeline_maker: t.Callable[..., api.QueuePipeline],
+    topic_item_maker: t.Callable[..., api.TopicItem],
+    fake_executor: api.Executor,
+) -> t.Callable[..., api.QueueItem]:
+    def maker() -> api.QueueItem:
+        return api.QueueItem(
+            name="test",
+            pipeline=queue_pipeline_maker(),
+            input=topic_item_maker(),
+            output={"default": [topic_item_maker()]},
+            executor=fake_executor.name,
+        )
+
+    return maker
+
+
+@pytest.fixture
+def session() -> t.Iterator[Session]:
     yield database.session_factory()()
 
 
 @pytest.fixture
-def static_definitions() -> Iterator[StaticDefinitions]:
+def static_definitions() -> t.Iterator[StaticDefinitions]:
     new_definitions = StaticDefinitions()
     yield new_definitions
 
 
 @pytest.fixture
+def fake_executor(
+    static_definitions: StaticDefinitions,
+) -> api.Executor:
+    executor = api.Executor(name="default", type="ProcessExecutor")
+    static_definitions.executors[executor.name] = executor
+    return executor
+
+
+@pytest.fixture
+def job_definition_maker(
+    queue_item_maker: t.Callable[..., api.QueueItem]
+) -> t.Callable[..., api.JobDefinition]:
+    def maker() -> api.JobDefinition:
+        return api.JobDefinition(
+            name="test", template=queue_item_maker(), minimal_interval="@weekly"
+        )
+
+    return maker
+
+
+@pytest.fixture
 def fake_job_definition(
     static_definitions: StaticDefinitions,
-    job_definition_maker: Callable[..., api.JobDefinition],
+    job_definition_maker: t.Callable[..., api.JobDefinition],
 ) -> api.JobDefinition:
     job_definition = job_definition_maker()
-    static_definitions.job_definitions["test"] = job_definition
+    static_definitions.job_definitions[job_definition.name] = job_definition
     return job_definition
 
 
 @pytest.fixture
 def client(
     static_definitions: StaticDefinitions,
-) -> Iterator[FlaskClient]:
+) -> t.Iterator[FlaskClient]:
     app = worker_manager_server.get_app(
         config={
             "TESTING": True,


### PR DESCRIPTION
@aviau | @KevGoDev 

next: Use the sync object to create the executor in the worker!