### PR TITLE
declarative: Loading declarative files follow symlinks

### DIFF
--- a/src/saturn_engine/utils/declarative_config.py
+++ b/src/saturn_engine/utils/declarative_config.py
@@ -68,7 +68,7 @@ def load_uncompiled_objects_from_path(path: str) -> list[UncompiledObject]:
 def load_uncompiled_objects_from_directory(config_dir: str) -> list[UncompiledObject]:
     uncompiled_objects: list[UncompiledObject] = list()
 
-    for root, _, filenames in os.walk(config_dir):
+    for root, _, filenames in os.walk(config_dir, followlinks=True):
         for filename in filenames:
             if not filename.endswith(".yaml"):
                 continue


### PR DESCRIPTION
@aviau | @KevGoDev 

This way I can setup environment folders:

```
topology/
  |-- production/
  |   |-- executors.yaml
  |   \-- common -> ../common/
  |-- staging/
  |   |-- executors.yaml
  |   \-- common -> ../common/
  \-- common/
      \-- jobs.yaml
```