### PR TITLE
inventory: Add RetryBatch to raise in next_batch to signal retry

### DIFF
--- a/src/saturn_engine/worker/inventory.py
+++ b/src/saturn_engine/worker/inventory.py
@@ -1,10 +1,12 @@
-from typing import Any
-from typing import Optional
+import typing as t
 
 import abc
 import asyncio
 import dataclasses
+import logging
 from collections.abc import AsyncIterator
+from datetime import timedelta
+from functools import cached_property
 
 import asyncstdlib as alib
 
@@ -14,45 +16,80 @@ from saturn_engine.utils.options import OptionsSchema
 @dataclasses.dataclass
 class Item:
     id: str
-    args: dict[str, Any]
+    args: dict[str, t.Any]
     tags: dict[str, str] = dataclasses.field(default_factory=dict)
+
+
+class MaxRetriesError(Exception):
+    pass
+
+
+class RetryBatch(Exception):
+    def __init__(self, *, delay: t.Optional[timedelta], max_retries: int = 1) -> None:
+        super().__init__(delay)
+        self.delay = delay
+        self.max_retries = max_retries
+
+    async def wait_delay(self) -> None:
+        if self.delay:
+            await asyncio.sleep(self.delay.total_seconds())
+
+    def check_max_retries(self, retries_count: int) -> None:
+        if retries_count >= self.max_retries:
+            raise MaxRetriesError() from self.__cause__
 
 
 class Inventory(abc.ABC, OptionsSchema):
     @abc.abstractmethod
-    async def next_batch(self, after: Optional[str] = None) -> list[Item]:
+    async def next_batch(self, after: t.Optional[str] = None) -> list[Item]:
         """Returns a batch of item with id greater than `after`."""
         raise NotImplementedError()
 
-    async def iterate(self, after: Optional[str] = None) -> AsyncIterator[Item]:
+    async def iterate(self, after: t.Optional[str] = None) -> AsyncIterator[Item]:
         """Returns an iterable that goes over the whole inventory."""
+        retries_count = 0
         while True:
-            batch = await self.next_batch(after)
+            try:
+                batch = await self.next_batch(after)
+            except RetryBatch as e:
+                e.check_max_retries(retries_count)
+                if e.__cause__:
+                    self.logger.error("Retrying to get batch", exc_info=e)
+                await e.wait_delay()
+                retries_count += 1
+                continue
+            else:
+                retries_count = 0
+
             if not batch:
                 return
             for item in batch:
                 yield item
             after = item.id
 
+    @cached_property
+    def logger(self) -> logging.Logger:
+        return logging.getLogger(__name__ + ".Inventory")
+
 
 class IteratorInventory(Inventory):
-    def __init__(self, *, batch_size: Optional[int] = None, **kwargs: object) -> None:
+    def __init__(self, *, batch_size: t.Optional[int] = None, **kwargs: object) -> None:
         self.batch_size = batch_size or 10
 
-    async def next_batch(self, after: Optional[str] = None) -> list[Item]:
+    async def next_batch(self, after: t.Optional[str] = None) -> list[Item]:
         batch: list[Item] = await alib.list(
             alib.islice(self.iterate(after=after), self.batch_size)
         )
         return batch
 
     @abc.abstractmethod
-    async def iterate(self, after: Optional[str] = None) -> AsyncIterator[Item]:
+    async def iterate(self, after: t.Optional[str] = None) -> AsyncIterator[Item]:
         raise NotImplementedError()
         yield
 
 
 class BlockingInventory(Inventory, abc.ABC):
-    async def next_batch(self, after: Optional[str] = None) -> list[Item]:
+    async def next_batch(self, after: t.Optional[str] = None) -> list[Item]:
         return await asyncio.get_event_loop().run_in_executor(
             None,
             self.next_batch_blocking,
@@ -60,5 +97,5 @@ class BlockingInventory(Inventory, abc.ABC):
         )
 
     @abc.abstractmethod
-    def next_batch_blocking(self, after: Optional[str] = None) -> list[Item]:
+    def next_batch_blocking(self, after: t.Optional[str] = None) -> list[Item]:
         raise NotImplementedError()

--- a/tests/worker/inventories/test_inventory.py
+++ b/tests/worker/inventories/test_inventory.py
@@ -1,0 +1,70 @@
+import typing as t
+
+from datetime import timedelta
+
+import pytest
+
+from saturn_engine.utils import utcnow
+from saturn_engine.worker.inventory import Inventory
+from saturn_engine.worker.inventory import Item
+from saturn_engine.worker.inventory import MaxRetriesError
+from saturn_engine.worker.inventory import RetryBatch
+from tests.conftest import FreezeTime
+
+
+class RetryingInventory(Inventory):
+    def __init__(
+        self, *, retry_delay: t.Optional[timedelta], retrying_count: int = 1
+    ) -> None:
+        self.retried = 0
+        self.retry_delay = retry_delay
+        self.retrying_count = retrying_count
+
+    async def next_batch(self, after: t.Optional[str] = None) -> list[Item]:
+        if self.retried == self.retrying_count:
+            return [Item(id="1", args={"x": 1})]
+        self.retried += 1
+        raise RetryBatch(delay=self.retry_delay, max_retries=5)
+
+
+@pytest.mark.asyncio
+async def test_next_batch_retry(frozen_time: FreezeTime) -> None:
+    start_date = utcnow()
+    inventory = RetryingInventory(retry_delay=None)
+    iterator = inventory.iterate()
+
+    assert (await iterator.__anext__()).id == "1"
+
+    # Didn't need to wait.
+    assert utcnow() == start_date
+    # And yet, it was retried.
+    assert inventory.retried == 1
+
+
+@pytest.mark.asyncio
+async def test_next_batch_retry_with_delay(frozen_time: FreezeTime) -> None:
+    start_date = utcnow()
+    inventory = RetryingInventory(retry_delay=timedelta(seconds=10), retrying_count=2)
+    iterator = inventory.iterate()
+
+    assert (await iterator.__anext__()).id == "1"
+
+    # Slept at least 10 seconds.
+    assert utcnow() >= (start_date + timedelta(seconds=20))
+    # And it was retried.
+    assert inventory.retried == 2
+
+
+@pytest.mark.asyncio
+async def test_next_batch_max_retries(frozen_time: FreezeTime) -> None:
+    start_date = utcnow()
+    inventory = RetryingInventory(retry_delay=timedelta(seconds=10), retrying_count=10)
+    iterator = inventory.iterate()
+
+    with pytest.raises(MaxRetriesError):
+        await iterator.__anext__()
+
+    # Slept at least 50 seconds.
+    assert utcnow() >= (start_date + timedelta(seconds=50))
+    # And it was retried.
+    assert inventory.retried == 6


### PR DESCRIPTION
@mlefebvre @aviau 

This allow async retry, especially useful in Blocking inventory, where we should return from the blocking function ASAP instead of retrying inside the blocking function.

As simple as:

```
def next_batch_blocking(...):
  try:
    stuff()
  except:
    raise RetryBatch(timedelta(seconds=60))
```