### PR TITLE
Ignore trace.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 test.db
+/trace.db
 /.venv-tools
 /dist
 *.egg-info


### PR DESCRIPTION
@isra17 | @aviau 

In our example pipeline we create a `trace.db` file which we don't want to push to our repository so I added it to our gitignore. 

See: https://github.com/Flared/saturn/blob/9c4dd70681f7b6d8a12810302a91f0cd221fc029/example/src/example/pipelines.py#L35

