### PR TITLE
inventory: Make Item.cursor optional

### DIFF
--- a/example/tests/inventory_tests.yaml
+++ b/example/tests/inventory_tests.yaml
@@ -8,10 +8,13 @@ spec:
   limit: 3
   items:
     - id: "0"
+      cursor: "0"
       args: {message: hello-0}
     - id: "1"
+      cursor: "1"
       args: {message: hello-1}
     - id: "2"
+      cursor: "2"
       args: {message: hello-2}
 ---
 apiVersion: saturn.flared.io/v1alpha1
@@ -25,4 +28,5 @@ spec:
   after: "2"
   items:
     - id: "3"
+      cursor: "3"
       args: {message: hello-3}

--- a/src/saturn_engine/worker/inventories/multi.py
+++ b/src/saturn_engine/worker/inventories/multi.py
@@ -17,7 +17,7 @@ from . import IteratorInventory
 
 class MultiItems(NamedTuple):
     ids: dict[str, str]
-    cursors: dict[str, str]
+    cursors: dict[str, Optional[str]]
     args: dict[str, dict[str, Any]]
 
 

--- a/src/saturn_engine/worker/inventory.py
+++ b/src/saturn_engine/worker/inventory.py
@@ -13,16 +13,18 @@ import asyncstdlib as alib
 
 from saturn_engine.utils.options import OptionsSchema
 
+MISSING = object()
+
 
 @dataclasses.dataclass
 class Item:
     args: dict[str, t.Any]
     id: str = dataclasses.field(default_factory=lambda: str(uuid.uuid4()))
-    cursor: str = None  # type: ignore[assignment]
+    cursor: t.Optional[str] = MISSING  # type: ignore[assignment]
     tags: dict[str, str] = dataclasses.field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if self.cursor is None:
+        if self.cursor is MISSING:
             self.cursor = self.id
 
 

--- a/tests/worker/inventories/test_chained_inventory.py
+++ b/tests/worker/inventories/test_chained_inventory.py
@@ -32,7 +32,7 @@ async def test_chained_inventory() -> None:
         services=None,
     )
     batch = await alib.list(inventory.iterate())
-    assert [(json.loads(i.id), json.loads(i.cursor), i.args) for i in batch] == [
+    assert [(json.loads(i.id), json.loads(i.cursor or ""), i.args) for i in batch] == [
         ({"a": "0"}, {"a": "0"}, {"a": {"a": 1}}),
         ({"a": "1"}, {"a": "1"}, {"a": {"a": 2}}),
         ({"a": "2"}, {"a": "2"}, {"a": {"a": 3}}),
@@ -45,7 +45,7 @@ async def test_chained_inventory() -> None:
     ]
 
     batch = await alib.list(inventory.iterate(after='{"b": "1"}'))
-    assert [(json.loads(i.id), json.loads(i.cursor), i.args) for i in batch] == [
+    assert [(json.loads(i.id), json.loads(i.cursor or ""), i.args) for i in batch] == [
         ({"b": "2"}, {"b": "2"}, {"b": {"b": "3"}}),
         ({"c": "0"}, {"c": "0"}, {"c": {"c": "1"}}),
         ({"c": "1"}, {"c": "1"}, {"c": {"c": "2"}}),

--- a/tests/worker/inventories/test_joined_inventory.py
+++ b/tests/worker/inventories/test_joined_inventory.py
@@ -27,7 +27,7 @@ async def test_joined_inventory() -> None:
         services=None,
     )
     batch = await alib.list(inventory.iterate())
-    assert [(json.loads(i.id), json.loads(i.cursor), i.args) for i in batch] == [
+    assert [(json.loads(i.id), json.loads(i.cursor or ""), i.args) for i in batch] == [
         ({"a": "0", "b": "0"}, {"b": "0"}, {"a": {"n": 1}, "b": {"c": "A"}}),
         ({"a": "0", "b": "1"}, {"b": "1"}, {"a": {"n": 1}, "b": {"c": "B"}}),
         ({"a": "0", "b": "2"}, {"b": "2"}, {"a": {"n": 1}, "b": {"c": "C"}}),
@@ -40,7 +40,7 @@ async def test_joined_inventory() -> None:
     ]
 
     batch = await alib.list(inventory.iterate(after='{"a": "0", "b": "1"}'))
-    assert [(json.loads(i.id), json.loads(i.cursor), i.args) for i in batch] == [
+    assert [(json.loads(i.id), json.loads(i.cursor or ""), i.args) for i in batch] == [
         ({"a": "1", "b": "2"}, {"a": "0", "b": "2"}, {"a": {"n": 2}, "b": {"c": "C"}}),
         ({"a": "2", "b": "0"}, {"a": "1", "b": "0"}, {"a": {"n": 3}, "b": {"c": "A"}}),
         ({"a": "2", "b": "1"}, {"a": "1", "b": "1"}, {"a": {"n": 3}, "b": {"c": "B"}}),
@@ -71,7 +71,7 @@ async def test_joined_inventory_flatten() -> None:
         services=None,
     )
     batch = await alib.list(inventory.iterate())
-    assert [(json.loads(i.id), json.loads(i.cursor), i.args) for i in batch] == [
+    assert [(json.loads(i.id), json.loads(i.cursor or ""), i.args) for i in batch] == [
         ({"a": "0", "b": "0"}, {"b": "0"}, {"n": 1, "c": "A"})
     ]
 
@@ -99,7 +99,7 @@ async def test_joined_inventory_alias() -> None:
         services=None,
     )
     batch = await alib.list(inventory.iterate())
-    assert [(json.loads(i.id), json.loads(i.cursor), i.args) for i in batch] == [
+    assert [(json.loads(i.id), json.loads(i.cursor or ""), i.args) for i in batch] == [
         (
             {"fruits": "0", "veggies": "0"},
             {"veggies": "0"},
@@ -138,7 +138,7 @@ async def test_joined_inventory_alias() -> None:
         services=None,
     )
     batch = await alib.list(inventory.iterate())
-    assert [(json.loads(i.id), json.loads(i.cursor), i.args) for i in batch] == [
+    assert [(json.loads(i.id), json.loads(i.cursor or ""), i.args) for i in batch] == [
         (
             {"fruits": "0", "veggies": "0"},
             {"veggies": "0"},


### PR DESCRIPTION
@mlefebvre 

I'm using `MISSING` to use as a sentinel to fallback to `id` by default. `None` is an actual valid value so we cannot use it as a sentinel anymore.