### PR TITLE
worker_manager: Add resource provider declaration.

### DIFF
--- a/src/saturn_engine/core/api.py
+++ b/src/saturn_engine/core/api.py
@@ -74,6 +74,7 @@ class Executor:
 class LockResponse:
     items: list[QueueItem]
     resources: list[ResourceItem]
+    resources_providers: list[ResourcesProviderItem]
     executors: list[Executor]
 
 

--- a/src/saturn_engine/worker/resources/provider.py
+++ b/src/saturn_engine/worker/resources/provider.py
@@ -66,3 +66,8 @@ class StaticResourcesProvider(ResourcesProvider["StaticResourcesProvider.Options
     async def open(self) -> None:
         for resource in self.options.resources:
             await self.add(resource)
+
+
+BUILTINS: dict[str, t.Type[ResourcesProvider]] = {
+    "StaticResourcesProvider": StaticResourcesProvider,
+}

--- a/src/saturn_engine/worker_manager/config/declarative.py
+++ b/src/saturn_engine/worker_manager/config/declarative.py
@@ -14,6 +14,7 @@ from .declarative_inventory import Inventory
 from .declarative_job import Job
 from .declarative_job_definition import JobDefinition
 from .declarative_resource import Resource
+from .declarative_resource import ResourcesProvider
 from .declarative_topic_item import TopicItem
 from .static_definitions import StaticDefinitions
 
@@ -86,6 +87,21 @@ def compile_static_definitions(
                 resource_item.name = f"{resource.metadata.name}-{i}"
             definitions.resources[resource_item.name] = resource_item
             definitions.resources_by_type[resource_item.type].append(resource_item)
+
+    for uncompied_resources_provider in objects_by_kind.pop(
+        "SaturnResourcesProvider",
+        dict(),
+    ).values():
+        resources_provider = fromdict(
+            uncompied_resources_provider.data, ResourcesProvider
+        )
+        resources_provider_item = resources_provider.to_core_object()
+        definitions.resources_providers[
+            resources_provider_item.name
+        ] = resources_provider_item
+        definitions.resources_by_type[resources_provider_item.resource_type].append(
+            resources_provider_item
+        )
 
     for object_kind in objects_by_kind.keys():
         raise Exception(f"Unsupported kind {object_kind}")

--- a/src/saturn_engine/worker_manager/config/declarative_resource.py
+++ b/src/saturn_engine/worker_manager/config/declarative_resource.py
@@ -25,3 +25,23 @@ class Resource(BaseObject):
             data=self.spec.data,
             default_delay=self.spec.default_delay,
         )
+
+
+@dataclasses.dataclass
+class ResourcesProviderSpec:
+    type: str
+    resource_type: str
+    options: dict[str, Any]
+
+
+@dataclasses.dataclass
+class ResourcesProvider(BaseObject):
+    spec: ResourcesProviderSpec
+
+    def to_core_object(self) -> api.ResourcesProviderItem:
+        return api.ResourcesProviderItem(
+            name=self.metadata.name,
+            type=self.spec.type,
+            resource_type=self.spec.resource_type,
+            options=self.spec.options,
+        )

--- a/src/saturn_engine/worker_manager/config/static_definitions.py
+++ b/src/saturn_engine/worker_manager/config/static_definitions.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import dataclasses
 from collections import defaultdict
 
@@ -6,6 +8,7 @@ from saturn_engine.core.api import InventoryItem
 from saturn_engine.core.api import JobDefinition
 from saturn_engine.core.api import QueueItem
 from saturn_engine.core.api import ResourceItem
+from saturn_engine.core.api import ResourcesProviderItem
 from saturn_engine.core.api import TopicItem
 
 
@@ -16,7 +19,10 @@ class StaticDefinitions:
     topics: dict[str, TopicItem] = dataclasses.field(default_factory=dict)
     job_definitions: dict[str, JobDefinition] = dataclasses.field(default_factory=dict)
     jobs: dict[str, QueueItem] = dataclasses.field(default_factory=dict)
-    resources: dict[str, ResourceItem] = dataclasses.field(default_factory=dict)
-    resources_by_type: dict[str, list[ResourceItem]] = dataclasses.field(
-        default_factory=lambda: defaultdict(list)
+    resources_providers: dict[str, ResourcesProviderItem] = dataclasses.field(
+        default_factory=dict
     )
+    resources: dict[str, ResourceItem] = dataclasses.field(default_factory=dict)
+    resources_by_type: dict[
+        str, list[t.Union[ResourceItem, ResourcesProviderItem]]
+    ] = dataclasses.field(default_factory=lambda: defaultdict(list))

--- a/tests/worker/conftest.py
+++ b/tests/worker/conftest.py
@@ -24,6 +24,7 @@ from saturn_engine.worker.executors.executable import ExecutableMessage
 from saturn_engine.worker.executors.parkers import Parkers
 from saturn_engine.worker.executors.queue import ExecutorQueue
 from saturn_engine.worker.pipeline_message import PipelineMessage
+from saturn_engine.worker.resources.provider import ResourcesProvider
 from saturn_engine.worker.services import Services
 from saturn_engine.worker.services.manager import ServicesManager
 from saturn_engine.worker.services.rabbitmq import RabbitMQService
@@ -37,7 +38,10 @@ from tests.utils import TimeForwardLoop
 def worker_manager_client() -> Mock:
     _worker_manager_client = create_autospec(WorkerManagerClient, instance=True)
     _worker_manager_client.lock.return_value = LockResponse(
-        items=[], resources=[], executors=[]
+        items=[],
+        resources=[],
+        resources_providers=[],
+        executors=[],
     )
     return _worker_manager_client
 
@@ -170,6 +174,20 @@ class FakeResource(Resource):
 @pytest.fixture
 def fake_resource_class() -> str:
     return __name__ + "." + FakeResource.__name__
+
+
+class FakeResourcesProvider(ResourcesProvider["FakeResourcesProvider.Options"]):
+    @dataclasses.dataclass
+    class Options:
+        pass
+
+    async def open(self) -> None:
+        pass
+
+
+@pytest.fixture
+def fake_resources_provider_class() -> str:
+    return __name__ + "." + FakeResourcesProvider.__name__
 
 
 @pytest.fixture

--- a/tests/worker/test_broker.py
+++ b/tests/worker/test_broker.py
@@ -73,6 +73,7 @@ async def test_broker_dummy(
                 data={"data": "fake"},
             ),
         ],
+        resources_providers=[],
         executors=[
             api.Executor(
                 name="e1", type=get_import_name(FakeExecutor), options={"ok": True}

--- a/tests/worker/test_work_manager.py
+++ b/tests/worker/test_work_manager.py
@@ -9,6 +9,7 @@ from saturn_engine.core.api import PipelineInfo
 from saturn_engine.core.api import QueueItem
 from saturn_engine.core.api import QueuePipeline
 from saturn_engine.core.api import ResourceItem
+from saturn_engine.core.api import ResourcesProviderItem
 from saturn_engine.core.api import TopicItem
 from saturn_engine.worker.work_manager import WorkManager
 from saturn_engine.worker.work_manager import WorkSync
@@ -17,13 +18,14 @@ from saturn_engine.worker.work_manager import WorkSync
 @pytest.mark.asyncio
 async def test_sync(
     fake_resource_class: str,
+    fake_resources_provider_class: str,
     fake_pipeline_info: PipelineInfo,
     work_manager: WorkManager,
     worker_manager_client: Mock,
 ) -> None:
     # Sync does nothing.
     worker_manager_client.lock.return_value = LockResponse(
-        items=[], resources=[], executors=[]
+        items=[], resources=[], resources_providers=[], executors=[]
     )
 
     work_sync = await work_manager.sync()
@@ -75,6 +77,20 @@ async def test_sync(
             ResourceItem(name="r1", type="FakeResource", data={"foo": "bar"}),
             ResourceItem(name="r2", type="FakeResource", data={"foo": "biz"}),
         ],
+        resources_providers=[
+            ResourcesProviderItem(
+                name="rp1",
+                type=fake_resources_provider_class,
+                resource_type="FakeResource",
+                options={"foo": "bar"},
+            ),
+            ResourcesProviderItem(
+                name="rp2",
+                type=fake_resources_provider_class,
+                resource_type="FakeResource",
+                options={"foo": "biz"},
+            ),
+        ],
         executors=[
             Executor(name="e1", type="FakeExecutor", options={"foo": "bar"}),
             Executor(name="e2", type="FakeExecutor", options={"foo": "bar"}),
@@ -84,14 +100,17 @@ async def test_sync(
     work_sync = await work_manager.sync()
     assert len(work_sync.queues.add) == 3
     assert len(work_sync.resources.add) == 2
+    assert len(work_sync.resources_providers.add) == 2
     assert len(work_sync.executors.add) == 2
     assert work_sync.queues.drop == []
     assert work_sync.resources.drop == []
+    assert work_sync.resources_providers.drop == []
     assert work_sync.executors.drop == []
 
     q2_work = work_manager.work_queue_by_name("q1")
     q3_work = work_manager.work_queue_by_name("q3")
     r2_resource = work_manager.worker_resources["r2"]
+    rp2_resource_provider = work_manager.worker_resources_providers["rp2"]
     e2_executor = work_manager.worker_executors["e2"]
 
     # New sync add 1 and drop 2 items.
@@ -127,6 +146,14 @@ async def test_sync(
         resources=[
             ResourceItem(name="r1", type="FakeResource", data={"foo": "bar"}),
         ],
+        resources_providers=[
+            ResourcesProviderItem(
+                name="rp1",
+                type=fake_resources_provider_class,
+                resource_type="FakeResource",
+                options={"foo": "bar"},
+            ),
+        ],
         executors=[
             Executor(name="e1", type="FakeExecutor", options={"foo": "bar"}),
         ],
@@ -135,8 +162,10 @@ async def test_sync(
     work_sync = await work_manager.sync()
     assert len(work_sync.queues.add) == 1
     assert len(work_sync.resources.add) == 0
+    assert len(work_sync.resources_providers.add) == 0
     assert len(work_sync.executors.add) == 0
     # Ensure the item dropped are the same queue object that were added.
     assert set(work_sync.queues.drop) == {q2_work, q3_work}
     assert set(work_sync.resources.drop) == {r2_resource}
+    assert set(work_sync.resources_providers.drop) == {rp2_resource_provider}
     assert set(e.name for e in work_sync.executors.drop) == {e2_executor.name}

--- a/tests/worker_manager/config/test_declarative.py
+++ b/tests/worker_manager/config/test_declarative.py
@@ -440,3 +440,21 @@ def test_resource_concurrency() -> None:
     assert len(static_definitions.resources) == 5
     for i in range(1, 6):
         assert f"test-resource-{i}" in static_definitions.resources
+
+
+def test_resources_provider() -> None:
+
+    resources_provider_str = """
+    apiVersion: saturn.flared.io/v1alpha1
+    kind: SaturnResourcesProvider
+    metadata:
+      name: test-resource-provider
+    spec:
+      type: TestApiKeyProvider
+      resource_type: TestApiKey
+      options:
+        url: "http://qwe.com"
+    """
+    static_definitions = load_definitions_from_str(resources_provider_str)
+    assert len(static_definitions.resources_providers) == 1
+    assert len(static_definitions.resources_by_type["TestApiKey"]) == 1


### PR DESCRIPTION
@aviau | @KevGoDev 

Add ResourcesProvider declaration in Topology and let the worker create them.

Coming in next PR: 

- `open`/`close` providers in worker.
- Have an `example` provider and test the whole thing.

I think that will be all after!