### PR TITLE
Add endpoint to reset job status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "saturn-engine"
-version = "0.3.1dev98"
+version = "0.3.1dev99"
 description = ""
 readme = "README.md"
 authors = ["Flare Systems <oss@flare.systems>"]

--- a/src/saturn_engine/core/api.py
+++ b/src/saturn_engine/core/api.py
@@ -147,5 +147,10 @@ class UpdateResponse:
 
 
 @dataclasses.dataclass
+class ResetResponse:
+    pass
+
+
+@dataclasses.dataclass
 class JobsSyncResponse:
     pass

--- a/src/saturn_engine/stores/jobs_store.py
+++ b/src/saturn_engine/stores/jobs_store.py
@@ -84,6 +84,30 @@ def update_job(
     session.execute(stmt)
 
 
+def reset_job(
+    name: str,
+    *,
+    session: AnySyncSession,
+) -> None:
+    stmt = (
+        update(Job)
+        .where(Job.name == name)
+        .values(
+            cursor=None,
+            completed_at=None,
+        )
+    )
+
+    job = get_job(session=session, name=name)
+
+    if not job:
+        raise Exception("Updating unknown job")
+
+    queues_store.reset_queue(name=job.queue_name, session=session)
+
+    session.execute(stmt)
+
+
 def set_failed(
     name: str,
     *,

--- a/src/saturn_engine/stores/queues_store.py
+++ b/src/saturn_engine/stores/queues_store.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import datetime
 
 from sqlalchemy import or_
@@ -68,9 +70,33 @@ def get_unassigned_queues(
     return unassigned_queues
 
 
+def get_queue(
+    name: str,
+    *,
+    session: AnySyncSession,
+) -> Optional[Queue]:
+    return session.get(Queue, name)
+
+
 def disable_queue(
     *,
     name: str,
     session: AnySyncSession,
 ) -> None:
     session.execute(update(Queue).where(Queue.name == name).values(enabled=False))
+
+
+def reset_queue(
+    *,
+    name: str,
+    session: AnySyncSession,
+) -> None:
+    session.execute(
+        update(Queue)
+        .where(Queue.name == name)
+        .values(
+            enabled=True,
+            assigned_to=None,
+            assigned_at=None,
+        )
+    )

--- a/src/saturn_engine/worker_manager/api/jobs.py
+++ b/src/saturn_engine/worker_manager/api/jobs.py
@@ -4,8 +4,10 @@ from saturn_engine.core.api import JobInput
 from saturn_engine.core.api import JobResponse
 from saturn_engine.core.api import JobsResponse
 from saturn_engine.core.api import JobsSyncResponse
+from saturn_engine.core.api import ResetResponse
 from saturn_engine.core.api import UpdateResponse
 from saturn_engine.database import session_scope
+from saturn_engine.models.job import Job
 from saturn_engine.stores import jobs_store
 from saturn_engine.utils.flask import Json
 from saturn_engine.utils.flask import abort
@@ -54,6 +56,16 @@ def update_job(job_name: str) -> Json[UpdateResponse]:
             session=session,
         )
         return jsonify(UpdateResponse())
+
+
+@bp.route("/reset", methods=("POST",))
+def reset_job() -> Json[ResetResponse]:
+    with session_scope() as session:
+        jobs: list[Job] = jobs_store.get_jobs(session=session)
+        for job in jobs:
+            jobs_store.reset_job(job.name, session=session)
+
+        return jsonify(ResetResponse())
 
 
 @bp.route("/sync", methods=("POST",))


### PR DESCRIPTION
Adding this endpoint so we can easily re-run pipelines when testing locally.