### PR TITLE
Pass an ExecutableMessage instead of PipelineMessage to hooks

### DIFF
--- a/src/saturn_engine/worker/executors/manager.py
+++ b/src/saturn_engine/worker/executors/manager.py
@@ -100,7 +100,7 @@ class ExecutorWorker:
 
         # Go through all queue in the Ready state.
         async for message in self.scheduler.run():
-            await self.services.s.hooks.message_scheduled.emit(message.message)
+            await self.services.s.hooks.message_scheduled.emit(message)
             await self.executor_queue.submit(message)
 
     async def close(self) -> None:

--- a/src/saturn_engine/worker/pipeline_message.py
+++ b/src/saturn_engine/worker/pipeline_message.py
@@ -12,6 +12,10 @@ class PipelineMessage:
     message: TopicMessage
 
     @property
+    def id(self) -> str:
+        return self.message.id
+
+    @property
     def missing_resources(self) -> set[str]:
         return {
             typ

--- a/src/saturn_engine/worker/services/hooks.py
+++ b/src/saturn_engine/worker/services/hooks.py
@@ -11,13 +11,13 @@ if t.TYPE_CHECKING:
     from saturn_engine.core import PipelineResults
     from saturn_engine.core.api import QueueItem
     from saturn_engine.worker.executors.bootstrap import PipelineBootstrap
+    from saturn_engine.worker.executors.executable import ExecutableMessage
     from saturn_engine.worker.executors.executable import ExecutableQueue
-    from saturn_engine.worker.pipeline_message import PipelineMessage
     from saturn_engine.worker.topic import Topic
 
 
 class MessagePublished(t.NamedTuple):
-    message: "PipelineMessage"
+    xmsg: "ExecutableMessage"
     topic: "Topic"
     output: "PipelineOutput"
 
@@ -27,10 +27,10 @@ class Hooks:
 
     hook_failed: AsyncEventHook[Exception]
 
-    message_polled: AsyncEventHook["PipelineMessage"]
-    message_scheduled: AsyncEventHook["PipelineMessage"]
-    message_submitted: AsyncEventHook["PipelineMessage"]
-    message_executed: AsyncContextHook["PipelineMessage", "PipelineResults"]
+    message_polled: AsyncEventHook["ExecutableMessage"]
+    message_scheduled: AsyncEventHook["ExecutableMessage"]
+    message_submitted: AsyncEventHook["ExecutableMessage"]
+    message_executed: AsyncContextHook["ExecutableMessage", "PipelineResults"]
     message_published: AsyncContextHook["MessagePublished", None]
     output_blocked: AsyncEventHook["Topic"]
 

--- a/src/saturn_engine/worker/work_factory.py
+++ b/src/saturn_engine/worker/work_factory.py
@@ -32,10 +32,8 @@ def build(queue_item: QueueItem, *, services: Services) -> ExecutableQueue:
     }
 
     return ExecutableQueue(
-        name=queue_item.name,
-        executor=queue_item.executor,
+        definition=queue_item,
         topic=topic,
-        pipeline=queue_item.pipeline,
         output=output,
         services=services,
     )

--- a/tests/worker/services/test_metrics.py
+++ b/tests/worker/services/test_metrics.py
@@ -33,7 +33,7 @@ class MockMetricsService(BaseMetricsService):
 @pytest.mark.asyncio
 async def test_metrics(services_manager: ServicesManager) -> None:
     data = Mock()
-    pipeline_params = {"pipeline": data.info.name}
+    pipeline_params = {"pipeline": data.message.info.name}
     metric = MockMetricsService(services_manager.services)
     await metric.on_message_polled(data)
     metric.mock.incr.assert_awaited_once_with(
@@ -63,7 +63,7 @@ async def test_metrics(services_manager: ServicesManager) -> None:
 @pytest.mark.asyncio
 async def test_metrics_message_executed(services_manager: ServicesManager) -> None:
     data = Mock()
-    pipeline_params = {"pipeline": data.info.name}
+    pipeline_params = {"pipeline": data.message.info.name}
     metric = MockMetricsService(services_manager.services)
 
     results = PipelineResults(
@@ -110,7 +110,7 @@ async def test_metrics_message_executed(services_manager: ServicesManager) -> No
 @pytest.mark.asyncio
 async def test_metrics_message_published(services_manager: ServicesManager) -> None:
     data = Mock()
-    params = {"pipeline": data.message.info.name, "topic": data.topic.name}
+    params = {"pipeline": data.xmsg.message.info.name, "topic": data.topic.name}
     metric = MockMetricsService(services_manager.services)
 
     hook_generator = metric.on_message_published(data)


### PR DESCRIPTION
@aviau @mlefebvre 

Refactoring, now backward compatible, but we don't use hooks in any external project anyway.

I need executable message so I can get all the metadata about where the message is coming from.