### PR TITLE
Add config property to JobSpec

### DIFF
--- a/src/saturn_engine/core/api.py
+++ b/src/saturn_engine/core/api.py
@@ -60,6 +60,7 @@ class QueueItem:
     input: Union[TopicItem, InventoryItem] = field(
         ObjectUnion(union={"topic": TopicItem, "inventory": InventoryItem})
     )
+    config: dict[str, Any] = dataclasses.field(default_factory=dict)
     executor: str = "default"
 
 

--- a/src/saturn_engine/core/topic.py
+++ b/src/saturn_engine/core/topic.py
@@ -7,12 +7,24 @@ import uuid
 
 @dataclasses.dataclass
 class TopicMessage:
+    #: Message arguments used to call the pipeline.
     args: dict[str, Optional[Any]]
+
+    #: Unique message id.
     id: str = dataclasses.field(default_factory=lambda: str(uuid.uuid4()))
+
+    #: Tags to attach to observability (logging, events, metrics and tracing).
     tags: dict[str, str] = dataclasses.field(default_factory=dict)
-    metadata: dict[str, Optional[Any]] = dataclasses.field(default_factory=dict)
+
+    #: Service-specific configuration overriding the job or global config.
+    config: dict[str, dict[str, Optional[Any]]] = dataclasses.field(
+        default_factory=dict
+    )
+
+    #: Service-specific data used in the message lifecycle.
+    metadata: dict[str, dict[str, Optional[Any]]] = dataclasses.field(
+        default_factory=dict
+    )
 
     def extend(self, args: dict[str, object]) -> "TopicMessage":
-        return self.__class__(
-            id=self.id, args=args | self.args, tags=self.tags, metadata=self.metadata
-        )
+        return dataclasses.replace(self, args=args | self.args)

--- a/src/saturn_engine/worker_manager/config/declarative_job.py
+++ b/src/saturn_engine/worker_manager/config/declarative_job.py
@@ -50,6 +50,7 @@ class JobSpec:
     input: t.Optional[JobInput] = None
     inputs: dict[str, JobInput] = dataclasses.field(default_factory=dict)
     output: dict[str, list[JobOutput]] = dataclasses.field(default_factory=dict)
+    config: dict[str, t.Any] = dataclasses.field(default_factory=dict)
     executor: str = "default"
 
     def to_core_objects(
@@ -80,6 +81,7 @@ class JobSpec:
                     info=self.pipeline.to_core_object(),
                     args=dict(),
                 ),
+                config=self.config,
                 executor=self.executor,
             )
 

--- a/tests/core/test_topic_message.py
+++ b/tests/core/test_topic_message.py
@@ -10,11 +10,11 @@ def test_save_load_topic_message() -> None:
             "none": None,
         },
         tags={"tag": "tag"},
-        metadata={"a": {"foo": "bar"}, "b": None},
+        metadata={"a": {"foo": "bar"}, "b": {"foo": None}},
     )
     m_loaded = fromdict(asdict(m), TopicMessage)
     assert m_loaded.args["hey"] == "ho"
     assert m_loaded.args["none"] is None
     assert m_loaded.tags["tag"] == "tag"
     assert m_loaded.metadata["a"] == {"foo": "bar"}
-    assert m_loaded.metadata["b"] is None
+    assert m_loaded.metadata["b"] == {"foo": None}

--- a/tests/worker_manager/api/test_job_definitions.py
+++ b/tests/worker_manager/api/test_job_definitions.py
@@ -49,6 +49,12 @@ spec:
     pipeline:
       name: something.saturn.pipelines.aa.bb
       resources: {"api_key": "GithubApiKey"}
+
+    config:
+      tracer:
+        sampler:
+          type: TraceIdRatioBased
+          options: {ratio: 0.1}
 """
     )
     static_definitions.job_definitions = new_definitions.job_definitions
@@ -84,6 +90,14 @@ spec:
                             "name": "something.saturn.pipelines.aa.bb",
                             "resources": {"api_key": "GithubApiKey"},
                         },
+                    },
+                    "config": {
+                        "tracer": {
+                            "sampler": {
+                                "type": "TraceIdRatioBased",
+                                "options": {"ratio": 0.1},
+                            }
+                        }
                     },
                 },
             }


### PR DESCRIPTION
Add `config` property to `JobSpec` so we can override some services setting on a job basis.

@KevGoDev | @mlefebvre 