### PR TITLE
Config override from jobs and messages

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -27,6 +27,7 @@ mypy_packages = [
     "pytest",
     "pytest-mock",
     "types-freezegun",
+    "mypy-typing-asserts",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ flake8-breakpoint = "*"
 flake8-isort = "*"
 isort = "*"
 mypy = "*"
+mypy-typing-asserts = "*"
 pytest = "*"
 nox-poetry = "*"
 pytest-asyncio = "*"
@@ -130,7 +131,7 @@ disallow_incomplete_defs = true
 disallow_untyped_defs = true
 disallow_untyped_calls = true
 namespace_packages = true
-plugins = "sqlalchemy.ext.mypy.plugin"
+plugins = ["sqlalchemy.ext.mypy.plugin", "mypy_typing_asserts.mypy_plugin"]
 
 [[tool.mypy.overrides]]
 module = [

--- a/src/saturn_engine/utils/config.py
+++ b/src/saturn_engine/utils/config.py
@@ -196,8 +196,8 @@ def sublayers(layers: list, name: str) -> list:
 
 
 def get_attr(obj: Any, name: str) -> Any:
-    if isinstance(obj, dict):
-        ikey_map = {k.lower(): k for k in obj}
+    if isinstance(obj, Mapping):
+        ikey_map = {k.lower(): k for k in obj.keys()}
         k = ikey_map.get(name, _MISSING)
         return obj.get(k, _MISSING)
 

--- a/tests/worker/test_executable.py
+++ b/tests/worker/test_executable.py
@@ -1,0 +1,88 @@
+import typing as t
+
+import dataclasses
+
+import pytest
+
+from saturn_engine.config import Config
+from saturn_engine.core import TopicMessage
+from saturn_engine.core.api import QueueItem
+from saturn_engine.worker.executors.executable import ExecutableMessage
+from saturn_engine.worker.executors.executable import ExecutableQueue
+
+
+class ServiceA:
+    x: str = "foo"
+
+
+class ServiceB:
+    y: str
+    z: str = "biz"
+
+
+@pytest.fixture
+def config(config: Config) -> Config:
+    return (
+        config.load_object(
+            {
+                "test-service-b": {"y": "bar"},
+            }
+        )
+        .register_interface("test-service-a", ServiceA)
+        .register_interface("test-service-b", ServiceB)
+    )
+
+
+def test_config_override(
+    executable_queue_maker: t.Callable[..., ExecutableQueue],
+    executable_maker: t.Callable[..., ExecutableMessage],
+    fake_queue_item: QueueItem,
+    config: Config,
+) -> None:
+    # No configuration override either in queue or message.
+    xqueue_no_conf = executable_queue_maker()
+
+    assert xqueue_no_conf.config.cast_namespace("test-service-a", ServiceA).x == "foo"
+    assert xqueue_no_conf.config.cast_namespace("test-service-b", ServiceB).y == "bar"
+    assert xqueue_no_conf.config.cast_namespace("test-service-b", ServiceB).z == "biz"
+
+    xmsg = executable_maker(executable_queue=xqueue_no_conf)
+
+    assert xmsg.config.cast_namespace("test-service-a", ServiceA).x == "foo"
+    assert xmsg.config.cast_namespace("test-service-b", ServiceB).y == "bar"
+    assert xmsg.config.cast_namespace("test-service-b", ServiceB).z == "biz"
+
+    # Configuration override from queue.
+    queue_item = dataclasses.replace(
+        fake_queue_item, config={"test-service-b": {"y": "bar-queue"}}
+    )
+    xqueue_conf_y = executable_queue_maker(definition=queue_item)
+    xmsg = executable_maker(executable_queue=xqueue_conf_y)
+
+    assert xmsg.config.cast_namespace("test-service-a", ServiceA).x == "foo"
+    assert xmsg.config.cast_namespace("test-service-b", ServiceB).y == "bar-queue"
+    assert xmsg.config.cast_namespace("test-service-b", ServiceB).z == "biz"
+
+    # Configuration override from message.
+    message = TopicMessage(args={}, config={"test-service-b": {"y": "bar-message"}})
+    xmsg = executable_maker(executable_queue=xqueue_no_conf, message=message)
+
+    assert xmsg.config.cast_namespace("test-service-a", ServiceA).x == "foo"
+    assert xmsg.config.cast_namespace("test-service-b", ServiceB).y == "bar-message"
+    assert xmsg.config.cast_namespace("test-service-b", ServiceB).z == "biz"
+
+    # Configuration message override queue
+    message = TopicMessage(args={}, config={"test-service-b": {"y": "bar-message"}})
+    xmsg = executable_maker(executable_queue=xqueue_conf_y, message=message)
+
+    assert xmsg.config.cast_namespace("test-service-a", ServiceA).x == "foo"
+    assert xmsg.config.cast_namespace("test-service-b", ServiceB).y == "bar-message"
+    assert xmsg.config.cast_namespace("test-service-b", ServiceB).z == "biz"
+
+    # Configuration override from queue and message
+    message = TopicMessage(args={}, config={"test-service-b": {"z": "biz-message"}})
+    xmsg = executable_maker(executable_queue=xqueue_conf_y, message=message)
+
+    assert xmsg.config.cast_namespace("test-service-a", ServiceA).x == "foo"
+    assert xmsg.config.cast_namespace("test-service-b", ServiceB).y == "bar-queue"
+    assert xmsg.config.cast_namespace("test-service-b", ServiceB).z == "biz-message"


### PR DESCRIPTION
@aviau  @jordsti for review

We can now use a message or queue to get configuration items. This allow to have contextualized config (Such as tracing settings for a specific job or specific message). As usual, everything is typed checked!

```python
tracing_config: TracingConfig = message.config.cast_namespace("tracer", TracerConfig)
```

Note: Please review #239 first, I need to rebase this PR on top of this one.