### PR TITLE
rabbitmq: Dont wait on closed topics

### DIFF
--- a/src/saturn_engine/worker/topic.py
+++ b/src/saturn_engine/worker/topic.py
@@ -14,6 +14,10 @@ from saturn_engine.utils.options import OptionsSchema
 TopicOutput = Union[AsyncContextManager[TopicMessage], TopicMessage]
 
 
+class TopicClosedError(Exception):
+    pass
+
+
 class Topic(OptionsSchema):
     name: str
 

--- a/tests/worker/topics/test_rabbitmq_topic.py
+++ b/tests/worker/topics/test_rabbitmq_topic.py
@@ -199,3 +199,13 @@ async def test_rabbitmq_topic_channel_closed(
     assert await topic.publish(message, wait=True)
 
     await topic.close()
+
+
+@pytest.mark.asyncio
+async def test_closed_rabbitmq_topic(
+    topic_maker: t.Callable[..., Awaitable[RabbitMQTopic]]
+) -> None:
+    topic = await topic_maker()
+    await topic.close()
+    with pytest.raises(Exception):
+        await topic.publish(TopicMessage(id="0", args={"n": 0}), wait=True)


### PR DESCRIPTION
@jordsti | @KevGoDev 

I found a bug where completed job close the topics before we process the output. When that happen and we end up publishing on a closed topic, this lead to an infinite try loop. This fix the infinite loop, another PR is coming to fix the output closed before all message are processed.