### PR TITLE
config: allow specifying db connection creator

### DIFF
--- a/src/saturn_engine/config_definitions.py
+++ b/src/saturn_engine/config_definitions.py
@@ -20,7 +20,7 @@ class WorkerManagerConfig:
     flask_host: str
     flask_port: int
     database_url: str
-    async_database_url: str
+    database_connection_creator: t.Optional[str]
     static_definitions_directories: list[str]
     static_definitions_jobs_selector: t.Optional[str]
     work_items_per_worker: int

--- a/src/saturn_engine/database.py
+++ b/src/saturn_engine/database.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import sessionmaker
 
 from saturn_engine.models import Base
 from saturn_engine.utils import lazy
+from saturn_engine.utils.inspect import import_name
 from saturn_engine.worker_manager.app import current_app
 
 AnySyncSession = Union[Session, _sqlalchemy_scoped_session]
@@ -60,9 +61,16 @@ def drop_all() -> None:
 
 def engine() -> Engine:
     init()
+    database_connection_creator: Optional[
+        str
+    ] = current_app.saturn.config.database_connection_creator
+    extra_args = {}
+    if database_connection_creator:
+        extra_args["creator"] = import_name(database_connection_creator)
     return create_engine(
         current_app.saturn.config.database_url,
         future=True,
+        **extra_args,
     )
 
 

--- a/src/saturn_engine/default_config.py
+++ b/src/saturn_engine/default_config.py
@@ -37,11 +37,7 @@ class config(SaturnConfig):
         flask_host = os.environ.get("SATURN_FLASK_HOST", "127.0.0.1")
         flask_port = int(os.environ.get("SATURN_FLASK_PORT", 5000))
         database_url: str = os.environ.get("SATURN_DATABASE_URL", "sqlite:///test.db")
-        async_database_url: str = (
-            os.environ.get("SATURN_DATABASE_URL", "sqlite:///test.db")
-            .replace("sqlite:/", "sqlite+aiosqlite:/")
-            .replace("postgresql:/", "postgresql+asyncpg:/")
-        )
+        database_connection_creator: t.Optional[str] = None
         static_definitions_directories: list[str] = os.environ.get(
             "SATURN_STATIC_DEFINITIONS_DIRS", "/opt/saturn/definitions"
         ).split(":")


### PR DESCRIPTION
Allow saturn users to specify a connection creator.

One use case is AWS IAM Auth which requires a fresh token for every connection.