### PR TITLE
Added default value for with_locals option for sentry

### DIFF
--- a/src/saturn_engine/worker/services/extras/sentry.py
+++ b/src/saturn_engine/worker/services/extras/sentry.py
@@ -208,7 +208,7 @@ def single_exception_from_remote_error_tuple(
     if client_options is None:
         with_locals = True
     else:
-        with_locals = client_options["with_locals"]
+        with_locals = client_options.get("with_locals", True)
 
     frames = [serialize_frame(frame, with_locals=with_locals) for frame in tb.stack]
 


### PR DESCRIPTION
We are currently generating a lot of errors since the `with_locals` option seems to be missing from our sentry client options.

I added a default value if this option is not present in our client options.