### PR TITLE
pydantic: Remove any intrusive pydantic usage

### DIFF
--- a/src/saturn_engine/config_definitions.py
+++ b/src/saturn_engine/config_definitions.py
@@ -1,8 +1,7 @@
 import typing as t
 
+import dataclasses
 from enum import Enum
-
-from pydantic import dataclasses
 
 
 class Env(Enum):

--- a/src/saturn_engine/core/api.py
+++ b/src/saturn_engine/core/api.py
@@ -3,11 +3,9 @@ from typing import Generic
 from typing import Optional
 from typing import TypeVar
 
+import dataclasses
 from dataclasses import field
 from datetime import datetime
-
-from pydantic import BaseModel
-from pydantic import dataclasses
 
 from .pipeline import PipelineInfo  # noqa: F401  # Reexport for public API
 from .pipeline import QueuePipeline
@@ -73,7 +71,8 @@ class LockResponse:
     executors: list[ComponentDefinition]
 
 
-class LockInput(BaseModel):
+@dataclasses.dataclass
+class LockInput:
     worker_id: str
 
 

--- a/src/saturn_engine/utils/tester/config/inventory_test.py
+++ b/src/saturn_engine/utils/tester/config/inventory_test.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import dataclasses
+import dataclasses
 
 from saturn_engine.core import Cursor
 from saturn_engine.utils.declarative_config import BaseObject

--- a/src/saturn_engine/utils/tester/config/pipeline_test.py
+++ b/src/saturn_engine/utils/tester/config/pipeline_test.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import dataclasses
+import dataclasses
 
 from saturn_engine.utils.declarative_config import BaseObject
 

--- a/src/saturn_engine/utils/tester/config/topic_test.py
+++ b/src/saturn_engine/utils/tester/config/topic_test.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from pydantic import dataclasses
+import dataclasses
 
 from saturn_engine.core import TopicMessage
 from saturn_engine.utils.declarative_config import BaseObject

--- a/src/saturn_engine/worker_manager/config/declarative_executor.py
+++ b/src/saturn_engine/worker_manager/config/declarative_executor.py
@@ -1,8 +1,7 @@
 from typing import Any
 
+import dataclasses
 from dataclasses import field
-
-from pydantic import dataclasses
 
 from saturn_engine.core import api
 from saturn_engine.utils.declarative_config import BaseObject

--- a/src/saturn_engine/worker_manager/config/declarative_inventory.py
+++ b/src/saturn_engine/worker_manager/config/declarative_inventory.py
@@ -1,8 +1,7 @@
 from typing import Any
 
+import dataclasses
 from dataclasses import field
-
-from pydantic import dataclasses
 
 from saturn_engine.core import api
 from saturn_engine.utils.declarative_config import BaseObject

--- a/src/saturn_engine/worker_manager/config/declarative_job.py
+++ b/src/saturn_engine/worker_manager/config/declarative_job.py
@@ -1,8 +1,7 @@
 import typing as t
 
+import dataclasses
 from dataclasses import field
-
-from pydantic import dataclasses
 
 from saturn_engine.core import api
 from saturn_engine.utils.declarative_config import BaseObject

--- a/src/saturn_engine/worker_manager/config/declarative_job_definition.py
+++ b/src/saturn_engine/worker_manager/config/declarative_job_definition.py
@@ -1,6 +1,6 @@
 import typing as t
 
-from pydantic import dataclasses
+import dataclasses
 
 from saturn_engine.core import api
 from saturn_engine.utils.declarative_config import BaseObject

--- a/src/saturn_engine/worker_manager/config/declarative_pipeline.py
+++ b/src/saturn_engine/worker_manager/config/declarative_pipeline.py
@@ -1,6 +1,5 @@
+import dataclasses
 from dataclasses import field
-
-from pydantic import dataclasses
 
 from saturn_engine.core import api
 

--- a/src/saturn_engine/worker_manager/config/declarative_resource.py
+++ b/src/saturn_engine/worker_manager/config/declarative_resource.py
@@ -1,7 +1,7 @@
 from typing import Any
 from typing import Optional
 
-from pydantic import dataclasses
+import dataclasses
 
 from saturn_engine.core import api
 from saturn_engine.utils.declarative_config import BaseObject

--- a/src/saturn_engine/worker_manager/config/declarative_topic_item.py
+++ b/src/saturn_engine/worker_manager/config/declarative_topic_item.py
@@ -1,8 +1,7 @@
 from typing import Any
 
+import dataclasses
 from dataclasses import field
-
-from pydantic import dataclasses
 
 from saturn_engine.core import api
 from saturn_engine.utils.declarative_config import BaseObject

--- a/tests/utils/test_options.py
+++ b/tests/utils/test_options.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from saturn_engine.utils.options import OptionsSchema
 from saturn_engine.utils.options import asdict
+from saturn_engine.utils.options import fromdict
 from saturn_engine.utils.options import json_serializer
 
 
@@ -20,6 +21,11 @@ class NestedObjectB:
 class Object:
     x: str
     y: datetime
+
+
+@dataclasses.dataclass
+class BetterObject(Object):
+    z: NestedObjectA
 
 
 class FromObject(OptionsSchema):
@@ -43,4 +49,15 @@ def test_json_serializer() -> None:
     assert (
         json_serializer({"x": datetime(2023, 1, 1, 10, 10, 10)})
         == '{"x": "2023-01-01T10:10:10"}'
+    )
+
+
+def test_inheritance() -> None:
+    a = fromdict({"x": "foo", "y": "2020-01-01T01:01:01"}, Object)
+    assert a == Object(x="foo", y=datetime(2020, 1, 1, 1, 1, 1))
+    b = fromdict(
+        {"x": "foo", "y": "2020-01-01T01:01:01", "z": {"fielda": "foo"}}, BetterObject
+    )
+    assert b == BetterObject(
+        x="foo", y=datetime(2020, 1, 1, 1, 1, 1), z=NestedObjectA(fielda="foo")
     )


### PR DESCRIPTION
@aviau @infherny 

Pydantic "transparent" dataclass usage is broken (as shared in another channel).

This fix ensure we only use Pydantic as a "schema" that we can use to parse data and then set to our dataclasses.

fwiw, I think eventually we should make `options.asdict`/`options.fromdict` internal, that's a bit of a design issue from Saturn. We should have made (de)serializer configurable and let third-party code manage how things are being serialized in between layers.