### PR TITLE
worker-manager: Add job/_state endpoint to batch sync jobs states

### DIFF
--- a/src/saturn_engine/client/worker_manager.py
+++ b/src/saturn_engine/client/worker_manager.py
@@ -4,6 +4,8 @@ import socket
 
 import aiohttp
 
+from saturn_engine.core.api import JobsStatesSyncInput
+from saturn_engine.core.api import JobsStatesSyncResponse
 from saturn_engine.core.api import LockInput
 from saturn_engine.core.api import LockResponse
 from saturn_engine.utils import urlcat
@@ -27,3 +29,9 @@ class WorkerManagerClient:
         json = asdict(LockInput(worker_id=self.worker_id))
         async with self.http_client.post(lock_url, json=json) as response:
             return fromdict(await response.json(), LockResponse)
+
+    async def sync(self, sync: JobsStatesSyncInput) -> JobsStatesSyncResponse:
+        state_url = urlcat(self.base_url, "api/jobs/_states")
+        json = asdict(sync)
+        async with self.http_client.put(state_url, json=json) as response:
+            return fromdict(await response.json(), JobsStatesSyncResponse)

--- a/src/saturn_engine/core/api.py
+++ b/src/saturn_engine/core/api.py
@@ -1,3 +1,4 @@
+import typing as t
 from typing import Any
 from typing import Generic
 from typing import Optional
@@ -47,7 +48,7 @@ class ResourcesProviderItem:
 
 @dataclasses.dataclass
 class QueueItem:
-    name: str
+    name: JobId
     pipeline: QueuePipeline
     output: dict[str, list[ComponentDefinition]]
     input: ComponentDefinition
@@ -74,6 +75,34 @@ class LockResponse:
 @dataclasses.dataclass
 class LockInput:
     worker_id: str
+
+
+@dataclasses.dataclass
+class JobCompletion:
+    completed_at: datetime
+    error: t.Optional[str] = None
+
+
+@dataclasses.dataclass
+class JobState:
+    cursor: t.Optional[Cursor] = None
+    cursors_states: dict[Cursor, dict] = dataclasses.field(default_factory=dict)
+    completion: t.Optional[JobCompletion] = None
+
+
+@dataclasses.dataclass
+class JobsStates:
+    jobs: t.Mapping[JobId, JobState] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass
+class JobsStatesSyncInput:
+    state: JobsStates
+
+
+@dataclasses.dataclass
+class JobsStatesSyncResponse:
+    pass
 
 
 @dataclasses.dataclass

--- a/src/saturn_engine/database.py
+++ b/src/saturn_engine/database.py
@@ -2,11 +2,11 @@ from typing import Any
 from typing import Callable
 from typing import Iterator
 from typing import Optional
-from typing import Union
 
 from contextlib import contextmanager
 
 import sqlalchemy.orm
+from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine import create_engine
 from sqlalchemy.orm import Session
@@ -16,26 +16,9 @@ from sqlalchemy.orm import sessionmaker
 from saturn_engine.models import Base
 from saturn_engine.utils import lazy
 from saturn_engine.utils.inspect import import_name
+from saturn_engine.utils.sqlalchemy import AnySyncSession
+from saturn_engine.utils.sqlalchemy import is_sqlite3_connection
 from saturn_engine.worker_manager.app import current_app
-
-AnySyncSession = Union[Session, _sqlalchemy_scoped_session]
-AnySession = AnySyncSession
-
-import sqlite3
-
-from sqlalchemy import event
-
-
-def is_sqlite3_connection(connection: Any) -> bool:
-    from sqlalchemy.dialects.sqlite import aiosqlite  # type: ignore
-
-    return isinstance(
-        connection,
-        (
-            aiosqlite.AsyncAdapt_aiosqlite_connection,
-            sqlite3.Connection,
-        ),
-    )
 
 
 @event.listens_for(Engine, "connect")

--- a/src/saturn_engine/models/__init__.py
+++ b/src/saturn_engine/models/__init__.py
@@ -1,9 +1,11 @@
 from .base import Base
 from .job import Job
+from .job import JobCursorState
 from .queue import Queue
 
 __all__ = [
     "Base",
     "Job",
     "Queue",
+    "JobCursorState",
 ]

--- a/src/saturn_engine/models/job.py
+++ b/src/saturn_engine/models/job.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import backref
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql.sqltypes import Text
+from sqlalchemy.types import JSON
 
 from saturn_engine.core import Cursor
 from saturn_engine.core import JobId
@@ -17,6 +18,13 @@ from saturn_engine.utils import utcnow
 
 from .base import Base
 from .types import UTCDateTime
+
+
+class JobCursorState(Base):
+    __tablename__ = "job_cursor_states"
+    job: Mapped[str] = Column(Text, ForeignKey("jobs.name"), primary_key=True)
+    cursor: Mapped[str] = Column(Text, primary_key=True)
+    state: Mapped[dict] = Column(JSON, nullable=False)
 
 
 class Job(Base):

--- a/src/saturn_engine/stores/jobs_store.py
+++ b/src/saturn_engine/stores/jobs_store.py
@@ -6,11 +6,11 @@ from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.orm import joinedload
 
-from saturn_engine.database import AnySession
-from saturn_engine.database import AnySyncSession
 from saturn_engine.models import Job
 from saturn_engine.stores import queues_store
 from saturn_engine.utils import utcnow
+from saturn_engine.utils.sqlalchemy import AnySession
+from saturn_engine.utils.sqlalchemy import AnySyncSession
 
 
 def create_job(

--- a/src/saturn_engine/stores/queues_store.py
+++ b/src/saturn_engine/stores/queues_store.py
@@ -5,9 +5,9 @@ from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.orm import joinedload
 
-from saturn_engine.database import AnySession
-from saturn_engine.database import AnySyncSession
 from saturn_engine.models import Queue
+from saturn_engine.utils.sqlalchemy import AnySession
+from saturn_engine.utils.sqlalchemy import AnySyncSession
 
 
 def create_queue(

--- a/src/saturn_engine/utils/sqlalchemy.py
+++ b/src/saturn_engine/utils/sqlalchemy.py
@@ -1,0 +1,34 @@
+import typing as t
+
+import sqlite3
+
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects import sqlite
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import scoped_session
+
+AnySyncSession = t.Union[Session, scoped_session]
+AnySession = AnySyncSession
+
+
+def upsert(session: AnySession) -> t.Callable[[object], postgresql.Insert]:
+    if not session.bind:
+        raise ValueError("Session is unbound")
+
+    if isinstance(session.bind.dialect, postgresql.dialect):
+        return postgresql.insert
+    elif isinstance(session.bind.dialect, sqlite.dialect):
+        return sqlite.insert
+    raise ValueError(f"Dialect {session.bind.dialect} not supported")
+
+
+def is_sqlite3_connection(connection: t.Any) -> bool:
+    from sqlalchemy.dialects.sqlite import aiosqlite  # type: ignore
+
+    return isinstance(
+        connection,
+        (
+            aiosqlite.AsyncAdapt_aiosqlite_connection,
+            sqlite3.Connection,
+        ),
+    )

--- a/src/saturn_engine/worker/executors/executable.py
+++ b/src/saturn_engine/worker/executors/executable.py
@@ -84,7 +84,7 @@ class ExecutableQueue:
         services: Services,
     ):
         self.definition = definition
-        self.name = definition.name
+        self.name: str = definition.name
         self.pipeline = definition.pipeline
         self.executor = definition.executor
 

--- a/src/saturn_engine/worker/work_manager.py
+++ b/src/saturn_engine/worker/work_manager.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from datetime import timedelta
 
 from saturn_engine.client.worker_manager import WorkerManagerClient
+from saturn_engine.core import JobId
 from saturn_engine.core.api import ComponentDefinition
 from saturn_engine.core.api import LockResponse
 from saturn_engine.core.api import QueueItem
@@ -53,7 +54,7 @@ class WorkSync:
         )
 
 
-WorkerItems = dict[str, ExecutableQueue]
+WorkerItems = dict[JobId, ExecutableQueue]
 
 
 class WorkManager:
@@ -114,7 +115,7 @@ class WorkManager:
 
         return ItemsSync(add=add_items, drop=drop_items)
 
-    def work_queue_by_name(self, name: str) -> Optional[ExecutableQueue]:
+    def work_queue_by_name(self, name: JobId) -> Optional[ExecutableQueue]:
         return self.worker_items.get(name)
 
     async def build_queues_for_worker_items(

--- a/src/saturn_engine/worker_manager/api/jobs.py
+++ b/src/saturn_engine/worker_manager/api/jobs.py
@@ -3,6 +3,8 @@ from flask import Blueprint
 from saturn_engine.core.api import JobInput
 from saturn_engine.core.api import JobResponse
 from saturn_engine.core.api import JobsResponse
+from saturn_engine.core.api import JobsStatesSyncInput
+from saturn_engine.core.api import JobsStatesSyncResponse
 from saturn_engine.core.api import JobsSyncResponse
 from saturn_engine.core.api import UpdateResponse
 from saturn_engine.database import session_scope
@@ -14,6 +16,7 @@ from saturn_engine.utils.flask import jsonify
 from saturn_engine.utils.flask import marshall_request
 from saturn_engine.worker_manager.app import current_app
 from saturn_engine.worker_manager.services.sync import sync_jobs
+from saturn_engine.worker_manager.services.sync import sync_jobs_states
 
 bp = Blueprint("jobs", __name__, url_prefix="/api/jobs")
 
@@ -65,3 +68,15 @@ def post_sync() -> Json[JobsSyncResponse]:
             session=session,
         )
     return jsonify(JobsSyncResponse())
+
+
+@bp.route("/_states", methods=("PUT", "POST"))
+def post_sync_jobs_states() -> Json[JobsStatesSyncResponse]:
+    """Sync jobs states to the database in batch."""
+    sync_input = marshall_request(JobsStatesSyncInput)
+    with session_scope() as session:
+        sync_jobs_states(
+            state=sync_input.state,
+            session=session,
+        )
+    return jsonify(JobsStatesSyncResponse())

--- a/src/saturn_engine/worker_manager/config/declarative_job.py
+++ b/src/saturn_engine/worker_manager/config/declarative_job.py
@@ -3,6 +3,7 @@ import typing as t
 import dataclasses
 from dataclasses import field
 
+from saturn_engine.core import JobId
 from saturn_engine.core import api
 from saturn_engine.utils.declarative_config import BaseObject
 from saturn_engine.worker_manager.config.declarative_pipeline import PipelineInfo
@@ -73,7 +74,7 @@ class JobSpec:
                 queue_item_name = f"{name}-{job_input_name}"
 
             yield api.QueueItem(
-                name=queue_item_name,
+                name=JobId(queue_item_name),
                 input=job_input.to_core_object(static_definitions),
                 output={
                     key: [t.to_core_object(static_definitions) for t in topics]

--- a/src/saturn_engine/worker_manager/services/sync.py
+++ b/src/saturn_engine/worker_manager/services/sync.py
@@ -1,13 +1,20 @@
+import typing as t
+
 import threading
 import time
 from datetime import datetime
 
 from croniter import croniter
+from sqlalchemy import select
 
-from saturn_engine.database import AnySyncSession
+from saturn_engine.core.api import JobsStates
+from saturn_engine.models import Job
+from saturn_engine.models.job import JobCursorState
 from saturn_engine.stores import jobs_store
 from saturn_engine.stores import queues_store
 from saturn_engine.utils import utcnow
+from saturn_engine.utils.sqlalchemy import AnySyncSession
+from saturn_engine.utils.sqlalchemy import upsert
 from saturn_engine.worker_manager.config.declarative import StaticDefinitions
 
 _SYNC_LOCK = threading.Lock()
@@ -77,3 +84,61 @@ def _sync_jobs(
             job.cursor = last_job.cursor
 
         session.commit()
+
+
+def sync_jobs_states(
+    state: JobsStates,
+    session: AnySyncSession,
+) -> None:
+    # Batch load all job definition name for cursors state.
+    job_with_cursors_states = [
+        job_id for job_id, job_state in state.jobs.items() if job_state.cursors_states
+    ]
+    jobs_definitions = session.execute(
+        select(Job.name, Job.job_definition_name).where(
+            Job.name.in_(job_with_cursors_states)
+        )
+    )
+    job_definition_by_name = {j.name: j.job_definition_name for j in jobs_definitions}
+
+    jobs_values = []
+    jobs_cursors = []
+
+    for job_id, job_state in state.jobs.items():
+        job_values: dict[str, t.Any] = {}
+        job_cursors: list[dict[str, t.Any]] = []
+
+        if job_state.cursor:
+            job_values["cursor"] = job_state.cursor
+        if job_state.completion:
+            job_values["completed_at"] = job_state.completion.completed_at
+            if (error := job_state.completion.error) is not None:
+                job_values["error"] = error
+        for cursor, cursor_state in job_state.cursors_states.items():
+            job_cursors.append(
+                {
+                    "job": job_definition_by_name.get(job_id) or job_id,
+                    "cursor": cursor,
+                    "state": cursor_state,
+                }
+            )
+
+        if job_values:
+            job_values["name"] = job_id
+            jobs_values.append(job_values)
+        if job_cursors:
+            jobs_cursors.extend(job_cursors)
+
+    if jobs_cursors:
+        cursors_stmt = upsert(session)(JobCursorState).values(jobs_cursors)
+        cursors_stmt = cursors_stmt.on_conflict_do_update(
+            index_elements=[
+                JobCursorState.job,
+                JobCursorState.cursor,
+            ],
+            set_={JobCursorState.state: cursors_stmt.excluded.state},
+        )
+        session.execute(cursors_stmt)
+
+    if jobs_values:
+        session.bulk_update_mappings(Job, jobs_values)

--- a/tests/worker/conftest.py
+++ b/tests/worker/conftest.py
@@ -17,6 +17,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
 from saturn_engine.client.worker_manager import WorkerManagerClient
 from saturn_engine.config import Config
+from saturn_engine.core import JobId
 from saturn_engine.core import PipelineInfo
 from saturn_engine.core import QueuePipeline
 from saturn_engine.core import Resource
@@ -172,7 +173,7 @@ def fake_queue_item(
     fake_pipeline_info: PipelineInfo,
 ) -> QueueItem:
     return QueueItem(
-        name="fake-queue",
+        name=JobId("fake-queue"),
         pipeline=QueuePipeline(
             info=fake_pipeline_info,
             args={},
@@ -232,7 +233,7 @@ def fake_executable_maker_with_output(
         output: t.Optional[dict[str, list[ComponentDefinition]]] = None,
     ) -> ExecutableMessage:
         queue_item = QueueItem(
-            name="fake-failing-queue",
+            name=JobId("fake-failing-queue"),
             pipeline=QueuePipeline(
                 info=fake_pipeline_info,
                 args={},

--- a/tests/worker/test_work_manager.py
+++ b/tests/worker/test_work_manager.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from saturn_engine.core import JobId
 from saturn_engine.core.api import ComponentDefinition
 from saturn_engine.core.api import LockResponse
 from saturn_engine.core.api import PipelineInfo
@@ -33,7 +34,7 @@ async def test_sync(
     worker_manager_client.lock.return_value = LockResponse(
         items=[
             QueueItem(
-                name="q1",
+                name=JobId("q1"),
                 input=ComponentDefinition(
                     name="t1", type="DummyInventory", options={"count": 1000}
                 ),
@@ -46,7 +47,7 @@ async def test_sync(
                 executor="e1",
             ),
             QueueItem(
-                name="q2",
+                name=JobId("q2"),
                 input=ComponentDefinition(
                     name="t2",
                     type="DummyTopic",
@@ -60,7 +61,7 @@ async def test_sync(
                 executor="e1",
             ),
             QueueItem(
-                name="q3",
+                name=JobId("q3"),
                 input=ComponentDefinition(
                     name="t3",
                     type="DummyTopic",
@@ -108,8 +109,8 @@ async def test_sync(
     assert work_sync.resources_providers.drop == []
     assert work_sync.executors.drop == []
 
-    q2_work = work_manager.work_queue_by_name("q1")
-    q3_work = work_manager.work_queue_by_name("q3")
+    q2_work = work_manager.work_queue_by_name(JobId("q1"))
+    q3_work = work_manager.work_queue_by_name(JobId("q3"))
     r2_resource = work_manager.worker_resources["r2"]
     rp2_resource_provider = work_manager.worker_resources_providers["rp2"]
     e2_executor = work_manager.worker_executors["e2"]
@@ -118,7 +119,7 @@ async def test_sync(
     worker_manager_client.lock.return_value = LockResponse(
         items=[
             QueueItem(
-                name="q2",
+                name=JobId("q2"),
                 input=ComponentDefinition(
                     name="t2",
                     type="DummyTopic",
@@ -132,7 +133,7 @@ async def test_sync(
                 executor="e1",
             ),
             QueueItem(
-                name="q4",
+                name=JobId("q4"),
                 input=ComponentDefinition(
                     name="t4",
                     type="DummyTopic",

--- a/tests/worker_manager/conftest.py
+++ b/tests/worker_manager/conftest.py
@@ -5,6 +5,7 @@ from flask.testing import FlaskClient
 from sqlalchemy.orm import Session
 
 from saturn_engine import database
+from saturn_engine.core import JobId
 from saturn_engine.core import api
 from saturn_engine.models import Base
 from saturn_engine.worker_manager import server as worker_manager_server
@@ -40,7 +41,7 @@ def queue_item_maker(
 ) -> t.Callable[..., api.QueueItem]:
     def maker() -> api.QueueItem:
         return api.QueueItem(
-            name="test",
+            name=JobId("test"),
             pipeline=queue_pipeline_maker(),
             input=topic_item_maker(),
             output={"default": [topic_item_maker()]},


### PR DESCRIPTION
@aviau @infherny 

I'm splitting my big branch into smaller one.

First chunk:

This add an API to batch a bunch of updates together. Following code will follow to periodically call this endpoint with all saturn internal state updates.