### PR TITLE
scheduler: Fix cleanup failing due to improper generator handling

### DIFF
--- a/src/saturn_engine/utils/asyncutils.py
+++ b/src/saturn_engine/utils/asyncutils.py
@@ -68,6 +68,13 @@ class TasksGroup:
 
         return done
 
+    async def wait_all(self) -> set[asyncio.Task]:
+        if not self.tasks:
+            return set()
+        done, _ = await asyncio.wait(self.tasks)
+        self.tasks.difference_update(done)
+        return done
+
     async def close(self, timeout: t.Optional[float] = None) -> None:
         # Cancel the update event task.
         self.updated_task.cancel()
@@ -120,7 +127,9 @@ class TasksGroupRunner(TasksGroup):
         self.is_running = False
         self.notify()
 
-    async def close(self, timeout: t.Optional[float] = None) -> None:
+    async def close(
+        self, timeout: t.Optional[float] = None, *, wait_all: bool = False
+    ) -> None:
         if self.is_running:
             # Stop the runner.
             self.stop()
@@ -128,17 +137,22 @@ class TasksGroupRunner(TasksGroup):
             if self._runner_task:
                 await self._runner_task
 
+        if wait_all:
+            tasks = await asyncio.wait_for(self.wait_all(), timeout=timeout)
+            self._log_tasks(tasks)
+
         # Clean the tasks.
         await super().close(timeout=timeout)
 
     async def run(self) -> None:
         while self.is_running:
             done = await self.wait()
-            for task in done:
-                if not task.cancelled() and isinstance(task.exception(), Exception):
-                    self.logger.error(
-                        "Task '%s' failed", task, exc_info=task.exception()
-                    )
+            self._log_tasks(done)
+
+    def _log_tasks(self, tasks: set[asyncio.Task]) -> None:
+        for task in tasks:
+            if not task.cancelled() and isinstance(task.exception(), Exception):
+                self.logger.error("Task '%s' failed", task, exc_info=task.exception())
 
 
 class DelayedThrottle(t.Generic[AsyncFNone]):

--- a/src/saturn_engine/worker/broker.py
+++ b/src/saturn_engine/worker/broker.py
@@ -94,7 +94,7 @@ class Broker:
             for resource in work_sync.resources.drop:
                 await self.resources_manager.remove(resource.key)
             for queue in work_sync.queues.drop:
-                await self.executors_manager.remove_queue(queue)
+                self.executors_manager.remove_queue(queue)
             for executor in work_sync.executors.drop:
                 await self.executors_manager.remove_executor(executor)
 

--- a/src/saturn_engine/worker/executors/executable.py
+++ b/src/saturn_engine/worker/executors/executable.py
@@ -1,5 +1,4 @@
-from typing import AsyncContextManager
-from typing import Optional
+import typing as t
 
 import asyncio
 import contextlib
@@ -26,7 +25,7 @@ class ExecutableMessage:
         message: PipelineMessage,
         parker: Parkers,
         output: dict[str, list[Topic]],
-        message_context: Optional[AsyncContextManager] = None,
+        message_context: t.Optional[t.AsyncContextManager] = None,
     ):
         self.message = message
         self._context = contextlib.AsyncExitStack()
@@ -103,7 +102,7 @@ class ExecutableQueue:
         try:
             async for message in self.topic.run():
                 context = None
-                if isinstance(message, AsyncContextManager):
+                if isinstance(message, t.AsyncContextManager):
                     context = message
                     message = await message.__aenter__()
 
@@ -120,8 +119,9 @@ class ExecutableQueue:
                 )
                 await self.services.s.hooks.message_polled.emit(executable_message)
                 await self.parkers.wait()
-                executable_message._context.enter_context(self.pending_context())
-                yield executable_message
+                with self.pending_context() as message_context:
+                    executable_message._context.enter_context(message_context())
+                    yield executable_message
         finally:
             await self.close()
 
@@ -144,14 +144,39 @@ class ExecutableQueue:
             await self.done.wait()
 
     @contextlib.contextmanager
-    def pending_context(self) -> Iterator[None]:
+    def pending_context(self) -> Iterator[t.Callable[[], t.ContextManager]]:
+        # Yield a new contextmanager to be attached to the message.
+        # This allow tracking when all message from this job have been processed
+        # so we can properly clean the jobs resources afterward. We need to yield
+        # the context from a context so that if the job's yield has an exception
+        # in the case of cancellation we won't to mark the pending message as not
+        # being pending anymore.
         self.pending_messages_count += 1
+        processed = False
+
+        @contextlib.contextmanager
+        def message_context() -> Iterator[None]:
+            nonlocal processed
+
+            try:
+                yield
+            finally:
+                if not processed:
+                    self.message_processed()
+                processed = True
+
         try:
-            yield
-        finally:
-            self.pending_messages_count -= 1
-            if self.is_closed and self.pending_messages_count == 0:
-                self.done.set()
+            yield message_context
+        except BaseException:
+            if not processed:
+                self.message_processed()
+            processed = True
+            raise
+
+    def message_processed(self) -> None:
+        self.pending_messages_count -= 1
+        if self.is_closed and self.pending_messages_count == 0:
+            self.done.set()
 
     @cached_property
     def config(self) -> LazyConfig:

--- a/src/saturn_engine/worker/executors/manager.py
+++ b/src/saturn_engine/worker/executors/manager.py
@@ -2,6 +2,7 @@ import asyncio
 
 from saturn_engine.core import api
 from saturn_engine.utils.asyncutils import TasksGroupRunner
+from saturn_engine.utils.log import getLogger
 from saturn_engine.worker.services import Services
 
 from . import Executor
@@ -21,15 +22,18 @@ class ExecutorsManager:
         self.services = services
         self.executors: dict[str, ExecutorWorker] = {}
         self.executors_tasks_group = TasksGroupRunner(name="executors")
+        self.logger = getLogger(__name__, self)
 
     def start(self) -> None:
         self.executors_tasks_group.start()
 
     async def close(self) -> None:
+        self.logger.debug("Closing executors")
         await asyncio.gather(
             *[executor.close() for executor in self.executors.values()]
         )
-        await self.executors_tasks_group.close()
+        self.logger.debug("Stopping executors tasks")
+        await self.executors_tasks_group.close(wait_all=True)
 
     def add_queue(self, queue: ExecutableQueue) -> None:
         executor = self.executors.get(queue.executor)
@@ -37,11 +41,11 @@ class ExecutorsManager:
             raise ValueError("Executor missing")
         executor.add_schedulable(queue)
 
-    async def remove_queue(self, queue: ExecutableQueue) -> None:
+    def remove_queue(self, queue: ExecutableQueue) -> None:
         executor = self.executors.get(queue.executor)
         if not executor:
             return
-        await executor.remove_schedulable(queue)
+        executor.remove_schedulable(queue)
 
     def add_executor(self, executor_definition: api.ComponentDefinition) -> None:
         if executor_definition.name in self.executors:
@@ -79,6 +83,7 @@ class ExecutorWorker:
             services=services,
         )
         self.scheduler: Scheduler[ExecutableMessage] = Scheduler()
+        self.logger = getLogger(__name__, self)
 
     @classmethod
     def from_item(
@@ -104,13 +109,16 @@ class ExecutorWorker:
         async for message in self.scheduler.run():
             await self.services.s.hooks.message_scheduled.emit(message)
             await self.executor_queue.submit(message)
+        self.logger.debug("Executor worker done")
 
     async def close(self) -> None:
+        self.logger.debug("Closing scheduler")
         await self.scheduler.close()
+        self.logger.debug("Closing executor queue")
         await self.executor_queue.close()
 
     def add_schedulable(self, schedulable: ExecutableQueue) -> None:
         self.scheduler.add(schedulable)
 
-    async def remove_schedulable(self, schedulable: ExecutableQueue) -> None:
-        await self.scheduler.remove(schedulable)
+    def remove_schedulable(self, schedulable: ExecutableQueue) -> None:
+        self.scheduler.remove(schedulable)

--- a/tests/worker/test_scheduler.py
+++ b/tests/worker/test_scheduler.py
@@ -59,7 +59,7 @@ async def test_scheduler(
         assert messages == {sentinel.schedulable1: 5, sentinel.schedulable2: 5}
 
         # Removing an item should cancel its task.
-        await scheduler.remove(schedulable2)
+        scheduler.remove(schedulable2)
 
         messages.clear()
         async for item in alib.islice(generator, 10):
@@ -141,7 +141,11 @@ async def test_scheduler_close_error(scheduler: Scheduler) -> None:
 
     schedulable = make_schedulable(iterable=error_close())
     scheduler.add(schedulable)
-    async for item in alib.islice(scheduler.run(), 10):
-        pass
-    await scheduler.close()
+    async with alib.scoped_iter(scheduler.run()) as generator:
+        async for item in alib.islice(generator, 10):
+            pass
+        await scheduler.close()
+        async for item in generator:
+            raise AssertionError()
+
     close_mock.assert_called_once()


### PR DESCRIPTION
@aviau @mlefebvre 

Seems to be a long standing bug in Saturn, we alway had issue with cleanup up after a job or hang when killing Saturn. Turns out we were trying to `aclose` a generated being `anext` (And we can't do that). This PR fix a few issues around this:

 - ExecutableQueue only wait for pending message if the message was yield. It could be cancelled while we were yielding, so we discard the pending message from the count in that case.
 - While removing a job from the scheduler, we ensure there is not `anext` in progress before calling `aclose`
 - We properly let the scheduler finish (By using `TasksGroupRunner.wait_all`) to give the job an opportunity to properly cleanup.