### PR TITLE
Add new /jobs/_states/fetch endpoint to batch fetch cursors states

### DIFF
--- a/src/saturn_engine/client/worker_manager.py
+++ b/src/saturn_engine/client/worker_manager.py
@@ -4,6 +4,8 @@ import socket
 
 import aiohttp
 
+from saturn_engine.core.api import FetchCursorsStatesInput
+from saturn_engine.core.api import FetchCursorsStatesResponse
 from saturn_engine.core.api import JobsStatesSyncInput
 from saturn_engine.core.api import JobsStatesSyncResponse
 from saturn_engine.core.api import LockInput
@@ -35,3 +37,11 @@ class WorkerManagerClient:
         json = asdict(sync)
         async with self.http_client.put(state_url, json=json) as response:
             return fromdict(await response.json(), JobsStatesSyncResponse)
+
+    async def fetch_cursors_states(
+        self, cursors: FetchCursorsStatesInput
+    ) -> FetchCursorsStatesResponse:
+        state_url = urlcat(self.base_url, "api/jobs/_states/cursors")
+        json = asdict(cursors)
+        async with self.http_client.put(state_url, json=json) as response:
+            return fromdict(await response.json(), FetchCursorsStatesResponse)

--- a/src/saturn_engine/core/api.py
+++ b/src/saturn_engine/core/api.py
@@ -94,6 +94,16 @@ class LockInput:
 
 
 @dataclasses.dataclass
+class FetchCursorsStatesInput:
+    cursors: dict[JobId, list[Cursor]]
+
+
+@dataclasses.dataclass
+class FetchCursorsStatesResponse:
+    cursors: dict[JobId, dict[Cursor, t.Optional[dict]]]
+
+
+@dataclasses.dataclass
 class JobCompletion:
     completed_at: datetime
     error: t.Optional[str] = None

--- a/src/saturn_engine/models/job.py
+++ b/src/saturn_engine/models/job.py
@@ -22,7 +22,7 @@ from .types import UTCDateTime
 
 class JobCursorState(Base):
     __tablename__ = "job_cursor_states"
-    job: Mapped[str] = Column(Text, ForeignKey("jobs.name"), primary_key=True)
+    job_definition_name: Mapped[str] = Column(Text, primary_key=True)
     cursor: Mapped[str] = Column(Text, primary_key=True)
     state: Mapped[dict] = Column(JSON, nullable=False)
 

--- a/src/saturn_engine/worker_manager/services/sync.py
+++ b/src/saturn_engine/worker_manager/services/sync.py
@@ -1,20 +1,13 @@
-import typing as t
-
 import threading
 import time
 from datetime import datetime
 
 from croniter import croniter
-from sqlalchemy import select
 
-from saturn_engine.core.api import JobsStates
-from saturn_engine.models import Job
-from saturn_engine.models.job import JobCursorState
 from saturn_engine.stores import jobs_store
 from saturn_engine.stores import queues_store
 from saturn_engine.utils import utcnow
 from saturn_engine.utils.sqlalchemy import AnySyncSession
-from saturn_engine.utils.sqlalchemy import upsert
 from saturn_engine.worker_manager.config.declarative import StaticDefinitions
 
 _SYNC_LOCK = threading.Lock()
@@ -84,61 +77,3 @@ def _sync_jobs(
             job.cursor = last_job.cursor
 
         session.commit()
-
-
-def sync_jobs_states(
-    state: JobsStates,
-    session: AnySyncSession,
-) -> None:
-    # Batch load all job definition name for cursors state.
-    job_with_cursors_states = [
-        job_id for job_id, job_state in state.jobs.items() if job_state.cursors_states
-    ]
-    jobs_definitions = session.execute(
-        select(Job.name, Job.job_definition_name).where(
-            Job.name.in_(job_with_cursors_states)
-        )
-    )
-    job_definition_by_name = {j.name: j.job_definition_name for j in jobs_definitions}
-
-    jobs_values = []
-    jobs_cursors = []
-
-    for job_id, job_state in state.jobs.items():
-        job_values: dict[str, t.Any] = {}
-        job_cursors: list[dict[str, t.Any]] = []
-
-        if job_state.cursor:
-            job_values["cursor"] = job_state.cursor
-        if job_state.completion:
-            job_values["completed_at"] = job_state.completion.completed_at
-            if (error := job_state.completion.error) is not None:
-                job_values["error"] = error
-        for cursor, cursor_state in job_state.cursors_states.items():
-            job_cursors.append(
-                {
-                    "job": job_definition_by_name.get(job_id) or job_id,
-                    "cursor": cursor,
-                    "state": cursor_state,
-                }
-            )
-
-        if job_values:
-            job_values["name"] = job_id
-            jobs_values.append(job_values)
-        if job_cursors:
-            jobs_cursors.extend(job_cursors)
-
-    if jobs_cursors:
-        cursors_stmt = upsert(session)(JobCursorState).values(jobs_cursors)
-        cursors_stmt = cursors_stmt.on_conflict_do_update(
-            index_elements=[
-                JobCursorState.job,
-                JobCursorState.cursor,
-            ],
-            set_={JobCursorState.state: cursors_stmt.excluded.state},
-        )
-        session.execute(cursors_stmt)
-
-    if jobs_values:
-        session.bulk_update_mappings(Job, jobs_values)


### PR DESCRIPTION
@aviau @mlefebvre 

New API to batch load the cursors states, aka:

```
POST /api/jobs/_states/fetch
{
  "cursors": {
    "job-123": ["a", "b"]
  }
}

200 OK
{
  "cursors": {
    "job-123": {"a": {"x": 1}, "b": {"x": 2}}
  }
}
```