### PR TITLE
JobState: Add method to fetch cursor

### DIFF
--- a/src/saturn_engine/client/worker_manager.py
+++ b/src/saturn_engine/client/worker_manager.py
@@ -41,7 +41,7 @@ class WorkerManagerClient:
     async def fetch_cursors_states(
         self, cursors: FetchCursorsStatesInput
     ) -> FetchCursorsStatesResponse:
-        state_url = urlcat(self.base_url, "api/jobs/_states/cursors")
+        state_url = urlcat(self.base_url, "api/jobs/_states/fetch")
         json = asdict(cursors)
-        async with self.http_client.put(state_url, json=json) as response:
+        async with self.http_client.post(state_url, json=json) as response:
             return fromdict(await response.json(), FetchCursorsStatesResponse)

--- a/src/saturn_engine/worker/executors/executable.py
+++ b/src/saturn_engine/worker/executors/executable.py
@@ -186,3 +186,6 @@ class ExecutableQueue:
                 self.definition.config,
             ]
         )
+
+    def __repr__(self) -> str:
+        return f"ExecutableQueue(name={self.name})"

--- a/src/saturn_engine/worker/services/job_state/service.py
+++ b/src/saturn_engine/worker/services/job_state/service.py
@@ -1,9 +1,14 @@
 import dataclasses
+from collections import defaultdict
 
+from saturn_engine.client.worker_manager import WorkerManagerClient
 from saturn_engine.core import Cursor
 from saturn_engine.core import JobId
+from saturn_engine.core.api import FetchCursorsStatesInput
+from saturn_engine.core.api import FetchCursorsStatesResponse
 from saturn_engine.core.api import JobsStatesSyncInput
 from saturn_engine.utils.asyncutils import DelayedThrottle
+from saturn_engine.utils.log import getLogger
 
 from .. import BaseServices
 from .. import Service
@@ -22,6 +27,28 @@ class Options:
     auto_flush: bool = True
 
 
+class CursorsStatesFetcher:
+    def __init__(self, *, client: WorkerManagerClient, fetch_delay: float = 0) -> None:
+        self.client = client
+        self.pending_queries: dict[JobId, set[Cursor]] = defaultdict(set)
+        self._delayed_fetch = DelayedThrottle(self._do_fetch, delay=fetch_delay)
+
+    async def _do_fetch(self) -> FetchCursorsStatesResponse:
+        queries = self.pending_queries
+        self.pending_queries = defaultdict(set)
+        cursors = {k: list(v) for k, v in queries.items()}
+        return await self.client.fetch_cursors_states(
+            FetchCursorsStatesInput(cursors=cursors)
+        )
+
+    async def fetch(
+        self, job_name: JobId, *, cursors: list[Cursor]
+    ) -> dict[Cursor, dict]:
+        self.pending_queries[job_name].update(cursors)
+        result = await self._delayed_fetch()
+        return result.cursors.get(job_name, {})
+
+
 class JobStateService(Service[Services, Options]):
     name = "job_state"
 
@@ -32,7 +59,11 @@ class JobStateService(Service[Services, Options]):
     _delayed_flush: DelayedThrottle
 
     async def open(self) -> None:
+        self.logger = getLogger(__name__, self)
         self._store = JobsStatesSyncStore()
+        self._cursors_fetcher = CursorsStatesFetcher(
+            client=self.services.api_client.client
+        )
         self._delayed_flush = DelayedThrottle(
             self.flush, delay=self.options.flush_delay
         )
@@ -61,11 +92,17 @@ class JobStateService(Service[Services, Options]):
         )
         self._maybe_flush()
 
+    async def fetch_cursors_states(
+        self, job_name: JobId, *, cursors: list[Cursor]
+    ) -> dict[Cursor, dict]:
+        return await self._cursors_fetcher.fetch(job_name, cursors=cursors)
+
     def _maybe_flush(self) -> None:
         if self.options.auto_flush:
-            self._delayed_flush()
+            self._delayed_flush.call_nowait()
 
     async def flush(self) -> None:
+        self.logger.debug("Flushing")
         with self._store.flush() as state:
             if not state.is_empty:
                 await self.flush_state(state)
@@ -76,4 +113,6 @@ class JobStateService(Service[Services, Options]):
         await self.services.api_client.client.sync(JobsStatesSyncInput(state=state))
 
     async def close(self) -> None:
+        self.logger.info("Closing")
+        self._maybe_flush()
         await self._delayed_flush.flush()

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -253,3 +253,11 @@ def register_hooks_handler(services: Services) -> AsyncMock:
         async_context_mock_handler(_hooks_handler.message_published)
     )
     return _hooks_handler
+
+
+class EqualAnyOrder:
+    def __init__(self, expected: t.Iterable):
+        self.expected = expected
+
+    def __eq__(self, other: t.Any) -> bool:
+        return list(sorted(self.expected)) == list(sorted(other))


### PR DESCRIPTION
@aviau @mlefebvre 

Add the code to fetch multiple cursors for multiples jobs at once from the Saturn worker service.