### PR TITLE
Support buffering in job iterator

### DIFF
--- a/src/saturn_engine/utils/config.py
+++ b/src/saturn_engine/utils/config.py
@@ -249,6 +249,9 @@ def check_type(obj: Any, typ: Any, scope: Any) -> bool:
     if typ is typing.Union:
         return any(check_type(obj, t, scope) for t in typ_args)
 
+    if typ is float:
+        return isinstance(obj, (float, int))
+
     if not isinstance(obj, typ):
         return False
 

--- a/src/saturn_engine/utils/iterators.py
+++ b/src/saturn_engine/utils/iterators.py
@@ -1,0 +1,43 @@
+import typing as t
+
+import asyncio
+
+import asyncstdlib as alib
+
+T = t.TypeVar("T")
+
+
+async def async_buffered(
+    iterator: t.AsyncIterator[T],
+    *,
+    buffer_size: t.Optional[int] = None,
+    flush_after: t.Optional[float] = None,
+) -> t.AsyncIterator[list[T]]:
+    items = []
+
+    async def next_slice() -> None:
+        async for item in alib.islice(alib.borrow(iterator), buffer_size):
+            items.append(item)
+
+    pending = {asyncio.create_task(next_slice())}
+
+    while True:
+        done, pending = await asyncio.wait(pending, timeout=flush_after)
+
+        if done and not items:
+            break
+
+        yield_items = items.copy()
+        items.clear()
+        if done:
+            pending = {asyncio.create_task(next_slice())}
+
+        yield yield_items
+
+
+async def async_flatten(
+    iterator: t.AsyncIterator[list[T]],
+) -> t.AsyncIterator[T]:
+    async for items in iterator:
+        for item in items:
+            yield item

--- a/src/saturn_engine/worker/job.py
+++ b/src/saturn_engine/worker/job.py
@@ -1,3 +1,6 @@
+import typing as t
+
+import dataclasses
 from collections.abc import AsyncGenerator
 
 import asyncstdlib as alib
@@ -5,16 +8,26 @@ import asyncstdlib as alib
 from saturn_engine.core import MessageId
 from saturn_engine.core import TopicMessage
 from saturn_engine.core.api import QueueItemWithState
+from saturn_engine.utils import iterators
+from saturn_engine.utils.config import LazyConfig
 from saturn_engine.utils.log import getLogger
+from saturn_engine.worker.inventories import Inventory
+from saturn_engine.worker.inventory import Item
 from saturn_engine.worker.services import Services
 from saturn_engine.worker.services.job_state.service import JobStateService
+from saturn_engine.worker.topics import Topic
+from saturn_engine.worker.topics import TopicOutput
 
-from .inventories import Inventory
-from .topics import Topic
-from .topics import TopicOutput
+JOB_NAMESPACE: t.Final[str] = "job"
 
 
 class Job(Topic):
+    @dataclasses.dataclass
+    class Options:
+        enable_cursors_states: bool = False
+        buffer_flush_after: float = 5
+        buffer_size: int = 10
+
     def __init__(
         self,
         *,
@@ -25,38 +38,49 @@ class Job(Topic):
         self.logger = getLogger(__name__, self)
         self.inventory = inventory
         self.services = services
-        self.batch_size = 10
         self.queue_item = queue_item
         self.state_service = services.cast_service(JobStateService)
+        self.config = LazyConfig([self.services.s.config.r, self.queue_item.config])
 
     async def run(self) -> AsyncGenerator[TopicOutput, None]:
         try:
-            cursor = self.queue_item.state.cursor
-            done = None
+            async with alib.scoped_iter(self._make_iterator()) as iterator:
+                async for item in iterator:
+                    cursor = item.cursor
+                    message = TopicMessage(
+                        id=MessageId(item.id),
+                        args=item.args,
+                        tags=item.tags,
+                        metadata=item.metadata,
+                    )
 
-            async with alib.scoped_iter(
-                self.inventory.iterate(after=cursor)
-            ) as iterator:
-                while done is not True:
-                    try:
-                        done = True
-                        async for item in alib.islice(iterator, self.batch_size):
-                            cursor = item.cursor
-                            done = False
-                            message = TopicMessage(
-                                id=MessageId(item.id),
-                                args=item.args,
-                                tags=item.tags,
-                                metadata=item.metadata,
-                            )
-                            yield message
-                    finally:
-                        if not done and cursor is not None:
-                            self.state_service.set_job_cursor(
-                                self.queue_item.name, cursor=cursor
-                            )
+                    yield message
+
+                    if cursor:
+                        self.state_service.set_job_cursor(
+                            self.queue_item.name, cursor=cursor
+                        )
 
             self.state_service.set_job_completed(self.queue_item.name)
         except Exception as e:
             self.logger.exception("Exception raised from job")
             self.state_service.set_job_failed(self.queue_item.name, error=e)
+
+    def _make_iterator(self) -> t.AsyncIterator[Item]:
+        cursor = self.queue_item.state.cursor
+        iterator = self.inventory.iterate(after=cursor)
+
+        # If we enable cursors states, we are going to decorate the iterator
+        # to buffer multiple messages together and load their states.
+        if self.options.enable_cursors_states:
+            buffered_iterator = iterators.async_buffered(
+                iterator,
+                flush_after=self.options.buffer_flush_after,
+                buffer_size=self.options.buffer_size,
+            )
+            iterator = iterators.async_flatten(buffered_iterator)
+        return iterator
+
+    @property
+    def options(self) -> Options:
+        return self.config.cast_namespace(JOB_NAMESPACE, self.Options)

--- a/tests/utils/test_iterators.py
+++ b/tests/utils/test_iterators.py
@@ -1,0 +1,45 @@
+import typing as t
+
+import asyncio
+
+import asyncstdlib as alib
+
+from saturn_engine.utils import iterators
+
+
+async def test_buffered() -> None:
+    # No param: Buffer the whole iterator.
+    iterator = alib.iter([1, 2, 3, 4, 5])
+    buf_it = iterators.async_buffered(iterator)
+    items = await alib.list(buf_it)
+    assert items == [[1, 2, 3, 4, 5]]
+
+    # `buffer_size` chunk into at most N items.
+    iterator = alib.iter([1, 2, 3, 4, 5])
+    buf_it = iterators.async_buffered(iterator, buffer_size=2)
+    items = await alib.list(buf_it)
+    assert items == [[1, 2], [3, 4], [5]]
+
+    # `flush_after` wait at most N seconds before flushing.
+    async def generator(xs: list[int]) -> t.AsyncIterator[int]:
+        for x in xs:
+            await asyncio.sleep(x)
+            yield x
+
+    iterator = generator([1, 2, 3, 4, 5, 3])
+    buf_it = iterators.async_buffered(iterator, flush_after=7)
+    items = await alib.list(buf_it)
+    assert items == [[1, 2, 3], [4], [5, 3]]
+
+    # Using all params return as soon one condition is true.
+    iterator = generator([1, 2, 3, 4, 5, 6])
+    buf_it = iterators.async_buffered(iterator, flush_after=8, buffer_size=2)
+    items = await alib.list(buf_it)
+    assert items == [[1, 2], [3, 4], [5], [6]]
+
+
+async def test_flatten() -> None:
+    iterator = alib.iter([[1, 2], [3, 4], [5]])
+    flatten_it = iterators.async_flatten(iterator)
+    items = await alib.list(flatten_it)
+    assert items == [1, 2, 3, 4, 5]

--- a/tests/worker/test_job.py
+++ b/tests/worker/test_job.py
@@ -1,0 +1,61 @@
+import typing as t
+
+import asyncio
+import dataclasses
+
+import asyncstdlib as alib
+import pytest
+
+from saturn_engine.core import Cursor
+from saturn_engine.core.api import QueueItemWithState
+from saturn_engine.worker.inventory import Inventory
+from saturn_engine.worker.inventory import Item
+from saturn_engine.worker.job import Job
+from saturn_engine.worker.services.job_state.service import JobStateService
+from saturn_engine.worker.services.manager import ServicesManager
+
+
+class FakeInventory(Inventory):
+    name = "fake_inventory"
+
+    @dataclasses.dataclass
+    class Options:
+        data: list[int]
+
+    def __init__(self, *args: t.Any, options: Options, **kwargs: t.Any) -> None:
+        self.options = options
+
+    async def next_batch(self, after: t.Optional[Cursor] = None) -> list[Item]:
+        raise NotImplementedError()
+
+    async def iterate(self, after: t.Optional[Cursor] = None) -> t.AsyncIterator[Item]:
+        for i, x in enumerate(self.options.data):
+            await asyncio.sleep(x)
+            yield Item(id=str(i), args={"x": x})
+
+
+@pytest.mark.asyncio
+async def test_job_iteration(
+    fake_queue_item: QueueItemWithState, services_manager: ServicesManager
+) -> None:
+    fake_queue_item.config["job"] = {
+        "enable_cursors_states": True,
+        "buffer_flush_after": 7,
+        "buffer_size": 2,
+    }
+    inventory = FakeInventory(options=FakeInventory.Options(data=[5, 4, 3, 2, 1]))
+    job = Job(
+        inventory=inventory,
+        queue_item=fake_queue_item,
+        services=services_manager.services,
+    )
+
+    items = await alib.list(job.run())
+    assert [i.id for i in items] == ["0", "1", "2", "3", "4"]  # type: ignore[union-attr]
+
+    job_state_service = services_manager.services.cast_service(JobStateService)
+    with job_state_service._store.flush() as state:
+        assert len(state.jobs) == 1
+        job_state = state.jobs[fake_queue_item.name]
+        assert job_state.cursor == "4"
+        assert job_state.completion


### PR DESCRIPTION
@slaroche  @infherny 

Adding some code so I can:

* Add options to a job (inventory) through its defintion in the form of:
  ```
  kind: JobDefitinion
  spec:
    template:
      config:
        job: {enable_states_cursors: true}
  ```
* Add some python utilities and logic in `Job` to buffer a bunch of message until either `buffer_size` is reached or `flush_after` has pass. This will allow to load a bunch of cursors states for many message at once.