### PR TITLE
Make ExecutableQueue cancellable while polling new message

### DIFF
--- a/src/saturn_engine/worker/executors/queue.py
+++ b/src/saturn_engine/worker/executors/queue.py
@@ -5,6 +5,7 @@ import sys
 
 from saturn_engine.core import PipelineOutput
 from saturn_engine.core import PipelineResults
+from saturn_engine.utils.asyncutils import Cancellable
 from saturn_engine.utils.asyncutils import TasksGroupRunner
 from saturn_engine.utils.log import getLogger
 from saturn_engine.worker.error_handling import process_pipeline_exception
@@ -18,7 +19,7 @@ from .executable import ExecutableMessage
 
 
 class ExecutorQueue:
-    CLOSE_TIMEOUT = datetime.timedelta(seconds=10)
+    CLOSE_TIMEOUT = datetime.timedelta(seconds=60)
 
     def __init__(
         self,
@@ -35,7 +36,7 @@ class ExecutorQueue:
         self.resources_manager = services.s.resources_manager
         self.executor = executor
         self.services = services
-        self.is_running = False
+        self.poll = Cancellable(self.queue.get)
 
     def start(self) -> None:
         self.is_running = True
@@ -50,7 +51,7 @@ class ExecutorQueue:
 
     async def run_queue(self) -> None:
         while self.is_running:
-            processable = await self.queue.get()
+            processable = await self.poll()
             processable._context.callback(self.queue.task_done)
             try:
                 async with processable._context:
@@ -67,7 +68,9 @@ class ExecutorQueue:
                             if exc_value is None or exc_traceback is None:
                                 raise
                             result = process_pipeline_exception(
-                                xmsg.queue.definition.output, exc_value, exc_traceback
+                                xmsg.queue.definition.output,
+                                exc_value,
+                                exc_traceback,
                             )
                             if not result:
                                 raise
@@ -172,11 +175,17 @@ class ExecutorQueue:
             await processable.unpark()
 
     async def close(self) -> None:
+        self.is_running = False
         # Shutdown the queue task first so we don't process any new item.
+        self.logger.debug("Closing processing tasks")
+        self.poll.cancel()
         await self.processing_tasks.close(timeout=self.CLOSE_TIMEOUT.total_seconds())
         # Delayed tasks waiting on resource
+        self.logger.debug("Closing submitting tasks")
         await self.submit_tasks.close()
         # Then close the output consuming task.
+        self.logger.debug("Closing consuming tasks")
         await self.consuming_tasks.close(timeout=self.CLOSE_TIMEOUT.total_seconds())
 
+        self.logger.debug("Closing executor")
         await self.executor.close()

--- a/tests/worker/test_broker.py
+++ b/tests/worker/test_broker.py
@@ -132,7 +132,7 @@ async def test_broker_dummy(
     assert wait_task in done
     assert broker_task in pending
 
-    assert hooks_handler.message_polled.await_count == 1001
+    assert hooks_handler.message_polled.await_count == 1002
     assert hooks_handler.message_scheduled.await_count == 1001
     assert hooks_handler.message_submitted.await_count == 1001
     assert hooks_handler.message_executed.before.await_count == 1000
@@ -168,7 +168,7 @@ async def test_broker_dummy(
         "saturn.pipeline.message",
         [
             metrics_capture.create_number_data_point(
-                1001,
+                1002,
                 attributes=pipeline_params | {"state": "polled"},
             ),
             metrics_capture.create_number_data_point(


### PR DESCRIPTION
Otherwise a broker doing nothing will take 10 seconds (close timeout) before giving up.