### PR TITLE
Add fanin inventory to create a single inventory out of many

### DIFF
--- a/src/saturn_engine/utils/__init__.py
+++ b/src/saturn_engine/utils/__init__.py
@@ -1,5 +1,6 @@
 import typing as t
 
+import builtins
 import collections
 import enum
 import threading
@@ -194,3 +195,13 @@ class CINamespace(collections.UserDict):
 
 def assert_never(x: t.NoReturn) -> t.NoReturn:
     raise AssertionError("Unhandled type: {}".format(type(x).__name__))
+
+
+ExceptionGroup: t.Type
+
+if not (ExceptionGroup := getattr(builtins, "ExceptionGroup", None)):  # type: ignore
+
+    class ExceptionGroup(Exception):  # type: ignore[no-redef]
+        def __init__(self, msg: str, errors: list[Exception]) -> None:
+            super().__init__(msg)
+            self.errors = errors

--- a/src/saturn_engine/utils/iterators.py
+++ b/src/saturn_engine/utils/iterators.py
@@ -1,6 +1,11 @@
 import typing as t
 
 import asyncio
+import contextlib
+
+import asyncstdlib as alib
+
+from . import ExceptionGroup
 
 T = t.TypeVar("T")
 
@@ -58,3 +63,54 @@ async def async_enter(
                 continue
             raise
         yield (context, item)
+
+
+@contextlib.asynccontextmanager
+async def scoped_aiters(
+    *iterators: t.AsyncIterator[T],
+) -> t.AsyncIterator[list[t.AsyncIterator[T]]]:
+    ctx = contextlib.AsyncExitStack()
+    scoped_aiters = [
+        await ctx.enter_async_context(alib.scoped_iter(i)) for i in iterators
+    ]
+    async with ctx:
+        yield scoped_aiters
+
+
+async def fanin(*iterators: t.AsyncIterator[T]) -> t.AsyncIterator[T]:
+    anext_tasks: dict[asyncio.Task, t.AsyncIterator[T]] = {
+        asyncio.create_task(alib.anext(i), name="fanin.anext"): i for i in iterators
+    }
+    errors: list[Exception] = []
+    while True:
+        if not anext_tasks:
+            break
+
+        done, _ = await asyncio.wait(
+            anext_tasks.keys(), return_when=asyncio.FIRST_COMPLETED
+        )
+        for task in done:
+            iterator = anext_tasks.pop(task)
+            if task.cancelled():
+                continue
+
+            e = task.exception()
+            if e is None:
+                yield task.result()
+            elif isinstance(e, StopAsyncIteration):
+                continue
+            elif isinstance(e, Exception):
+                for task in anext_tasks:
+                    if task not in done:
+                        task.cancel()
+                errors.append(e)
+            else:
+                raise e
+
+            if not errors:
+                anext_tasks[
+                    asyncio.create_task(alib.anext(iterator), name="fanin.anext")
+                ] = iterator
+
+    if errors:
+        raise ExceptionGroup("One iterator failed", errors)

--- a/src/saturn_engine/worker/inventories/fanin.py
+++ b/src/saturn_engine/worker/inventories/fanin.py
@@ -1,0 +1,44 @@
+import typing as t
+
+import dataclasses
+import json
+from contextlib import AsyncExitStack
+
+import asyncstdlib as alib
+
+from saturn_engine.core.api import ComponentDefinition
+from saturn_engine.core.types import Cursor
+from saturn_engine.utils import iterators
+from saturn_engine.worker.inventory import Item
+from saturn_engine.worker.inventory import IteratorInventory
+from saturn_engine.worker.services import Services
+from saturn_engine.worker.work_factory import build_inventory
+
+
+class FanIn(IteratorInventory):
+    @dataclasses.dataclass
+    class Options:
+        inputs: list[ComponentDefinition]
+
+    def __init__(self, options: Options, services: Services, **kwargs: object) -> None:
+        super().__init__()
+
+        self.inputs = {
+            input_def.name: build_inventory(input_def, services=services)
+            for input_def in options.inputs
+        }
+
+    async def iterate(self, after: t.Optional[Cursor] = None) -> t.AsyncIterator[Item]:
+        cursors = json.loads(after) if after else {}
+
+        async with AsyncExitStack() as ctx:
+            aiters: list[t.AsyncIterator[tuple[str, Item]]] = []
+            for k, inventory in self.inputs.items():
+                i_iter = inventory.iterate(after=cursors.get(k))
+                j_iter = alib.map(lambda m: (k, m), i_iter)
+                k_iter = alib.scoped_iter(j_iter)
+                aiters.append(await ctx.enter_async_context(k_iter))
+
+            async for name, message in iterators.fanin(*aiters):
+                cursors[name] = message.cursor
+                yield dataclasses.replace(message, cursor=Cursor(json.dumps(cursors)))

--- a/src/saturn_engine/worker/inventories/static.py
+++ b/src/saturn_engine/worker/inventories/static.py
@@ -18,7 +18,7 @@ class StaticInventory(Inventory):
         self.items = options.items
 
     async def next_batch(self, after: t.Optional[Cursor] = None) -> list[Item]:
-        begin = int(after) + 1 if after else 0
+        begin = int(after) + 1 if after is not None else 0
         return [
             Item(id=MessageId(str(i)), args=args)
             for i, args in enumerate(self.items[begin:], start=begin)

--- a/tests/worker/inventories/test_fanin.py
+++ b/tests/worker/inventories/test_fanin.py
@@ -1,0 +1,36 @@
+import asyncstdlib as alib
+import pytest
+
+from saturn_engine.core.types import Cursor
+from saturn_engine.core.types import MessageId
+from saturn_engine.worker.inventories.fanin import FanIn
+from saturn_engine.worker.inventory import Item
+
+
+@pytest.mark.asyncio
+async def test_fanin_inventory() -> None:
+    inventory = FanIn.from_options(
+        {
+            "inputs": [
+                {
+                    "name": "a",
+                    "type": "StaticInventory",
+                    "options": {"items": [{"n": 0}, {"n": 1}, {"n": 2}, {"n": 3}]},
+                },
+                {
+                    "name": "b",
+                    "type": "StaticInventory",
+                    "options": {"items": [{"n": 4}, {"n": 5}]},
+                },
+            ],
+            "batch_size": 10,
+        },
+        services=None,
+    )
+    messages = await alib.list(inventory.iterate())
+    assert {m.args["n"] for m in messages} == set(range(6))
+
+    messages = await alib.list(inventory.iterate(after=Cursor('{"a": "3", "b": "0"}')))
+    assert messages == [
+        Item(id=MessageId("1"), cursor='{"a": "3", "b": "1"}', args={"n": 5})
+    ]


### PR DESCRIPTION
@mlefebvre @aviau 

I need this so I can have a job with multiple inventory that all use the same cursors states. As it turns out, having multuple `inputs` on a job create many sub-jobs and does not share the same `job_definition_name`. This `FanIn` inventory seems to be the simplest way to deal with this for now without redefining too many concept...