### PR TITLE
Limit output logs to only 10 items

### DIFF
--- a/src/saturn_engine/worker/services/loggers/logger.py
+++ b/src/saturn_engine/worker/services/loggers/logger.py
@@ -174,7 +174,8 @@ class Logger(Service[BaseServices, "Logger.Options"]):
 
     def result_data(self, results: PipelineResults) -> dict[str, t.Any]:
         return {
-            "output": [self.output_data(o) for o in results.outputs],
+            "output": [self.output_data(o) for o in results.outputs[:10]],
+            "output_count": len(results.outputs),
             "resources": self.resources_used(results.resources),
         }
 

--- a/tests/worker/services/test_logger.py
+++ b/tests/worker/services/test_logger.py
@@ -92,6 +92,7 @@ async def test_logger_message_executed(
             "resources": {FakeResource._typename(): "r1"},
             "pipeline": "tests.worker.services.test_logger.fake_pipeline",
             "result": {
+                "output_count": 1,
                 "output": [
                     {
                         "channel": "default",


### PR DESCRIPTION
Should clena the log from high output volumes.

@infherny 