### PR TITLE
More Error Handling

### DIFF
--- a/example/definitions/simple.yaml
+++ b/example/definitions/simple.yaml
@@ -114,6 +114,11 @@ spec:
         - topic: stdout
       error::ZeroDivisionError:
         - topic: logging-error
+        - error_handler:
+            set_handled: false
+            republish:
+              channel: default
+              max_retry: 5
 
     pipeline:
       name: example.pipelines.echo_with_error

--- a/example/tests/pipeline_tests.yaml
+++ b/example/tests/pipeline_tests.yaml
@@ -67,8 +67,9 @@ spec:
     - outputs:
         - channel: error::ZeroDivisionError
           args:
+            cause: __any__
             error:
-              type: ZeroDivisionError
+              type: builtins.ZeroDivisionError
               module: 'example.pipelines'
               message: division by zero
               traceback: __any__
@@ -91,8 +92,9 @@ spec:
     - outputs:
         - channel: error:.*Ignorable Exception.*:Exception
           args:
+            cause: __any__
             error:
-              type: Exception
+              type: builtins.Exception
               module: 'example.pipelines'
               message: Ignorable Exception
               traceback: __any__

--- a/src/saturn_engine/core/api.py
+++ b/src/saturn_engine/core/api.py
@@ -26,6 +26,21 @@ class ComponentDefinition:
 
 
 @dataclasses.dataclass
+class RepublishOptions:
+    channel: str
+    max_retry: int
+
+
+@dataclasses.dataclass
+class ErrorHandler:
+    set_handled: bool = True
+    republish: t.Optional[RepublishOptions] = None
+
+
+OutputDefinition = t.Union[ComponentDefinition, ErrorHandler]
+
+
+@dataclasses.dataclass
 class ResourceRateLimitItem:
     rate_limits: list[str]
     strategy: str = "fixed-window"
@@ -52,7 +67,7 @@ class ResourcesProviderItem:
 class QueueItem:
     name: JobId
     pipeline: QueuePipeline
-    output: dict[str, list[ComponentDefinition]]
+    output: dict[str, list[OutputDefinition]]
     input: ComponentDefinition
     config: dict[str, Any] = field(default_factory=dict)
     labels: dict[str, str] = field(default_factory=dict)

--- a/src/saturn_engine/utils/tester/pipeline_test.py
+++ b/src/saturn_engine/utils/tester/pipeline_test.py
@@ -45,13 +45,18 @@ def run_saturn_pipeline_test(
         pipeline_result = None
         try:
             pipeline_result = bootstraper.bootstrap_pipeline(pipeline_message)
-        except Exception as err:
-            _, exc_value, exc_traceback = sys.exc_info()
+        except Exception:
+            exc_type, exc_value, exc_traceback = sys.exc_info()
+
             # Shouldn't be None but we want to make mypy happy
-            if exc_value is None or exc_traceback is None:
-                raise err
+            assert exc_type and exc_value and exc_traceback  # noqa: S101
+
             pipeline_result = process_pipeline_exception(
-                job_definition.template.output, exc_value, exc_traceback
+                queue=job_definition.template,
+                message=pipeline_message.message,
+                exc_type=exc_type,
+                exc_value=exc_value,
+                exc_traceback=exc_traceback,
             )
             if pipeline_result is None:
                 raise

--- a/src/saturn_engine/worker/error_handling.py
+++ b/src/saturn_engine/worker/error_handling.py
@@ -1,19 +1,18 @@
 from typing import Optional
 from typing import Type
-from typing import cast
 
+import logging
 import re
 from dataclasses import dataclass
 from functools import lru_cache
 from textwrap import dedent
 from types import TracebackType
 
-from saturn_engine.core.api import ComponentDefinition
+from saturn_engine.core.api import QueueItem
 from saturn_engine.core.error import ErrorMessageArgs
 from saturn_engine.core.pipeline import PipelineOutput
 from saturn_engine.core.pipeline import PipelineResults
 from saturn_engine.core.topic import TopicMessage
-from saturn_engine.utils import inspect as extra_inspect
 from saturn_engine.utils.traceback_data import TracebackData
 from saturn_engine.worker.executors.bootstrap import RemoteException
 
@@ -21,7 +20,7 @@ from saturn_engine.worker.executors.bootstrap import RemoteException
 @dataclass
 class ExceptionDetails:
     message: str
-    exception_type: Type[BaseException]
+    exception_type: str
     module: str
     lineno: int
     traceback: TracebackData
@@ -30,57 +29,77 @@ class ExceptionDetails:
 @dataclass
 class ExceptionFilter:
     message_pattern: Optional[re.Pattern]
-    exception_type: Type[BaseException]
+    exception_type: Optional[re.Pattern]
     module_pattern: Optional[re.Pattern]
     lineno: int
 
 
 def process_pipeline_exception(
-    outputs: dict[str, list[ComponentDefinition]],
+    *,
+    queue: QueueItem,
+    message: TopicMessage,
+    exc_type: Type[BaseException],
     exc_value: BaseException,
     exc_traceback: TracebackType,
 ) -> Optional[PipelineResults]:
+    outputs = queue.output
+    exc_details = get_exception_details(exc_type, exc_value, exc_traceback)
+
     # Match the exception and consume it if found, else reraise the exception
     for channel in outputs.keys():
         if not is_output_error_handler(channel):
             continue
 
-        exc_filter = parse_warning_filter(channel, escape=False)
-        exc_details = get_exception_details(exc_value, exc_traceback)
+        try:
+            exc_filter = parse_warning_filter(channel, escape=False)
 
-        if not does_error_match(exception=exc_details, exception_filter=exc_filter):
-            continue
+            if not does_error_match(exception=exc_details, exception_filter=exc_filter):
+                continue
 
-        return PipelineResults(
-            outputs=[
-                PipelineOutput(
-                    channel=channel,
-                    message=TopicMessage(
-                        args={
-                            "error": ErrorMessageArgs(
-                                type=exc_details.exception_type.__name__,
-                                module=exc_details.module,
-                                message=str(exc_value),
-                                traceback=exc_details.traceback,
-                            )
-                        }
-                    ),
-                )
-            ],
-            resources=[],
-        )
+            return PipelineResults(
+                outputs=[
+                    PipelineOutput(
+                        channel=channel,
+                        message=TopicMessage(
+                            args={
+                                "cause": message,
+                                "error": ErrorMessageArgs(
+                                    type=exc_details.exception_type,
+                                    module=exc_details.module,
+                                    message=exc_details.message,
+                                    traceback=exc_details.traceback,
+                                ),
+                            }
+                        ),
+                    )
+                ],
+                resources=[],
+            )
+        except Exception:
+            logging.getLogger(__name__).exception(
+                "Failed to process error channel", extra={"data": {"channel": channel}}
+            )
     return None
 
 
 def does_error_match(
     *, exception: ExceptionDetails, exception_filter: ExceptionFilter
 ) -> bool:
+    exc_type = exception.exception_type
+    exc_type_re = exception_filter.exception_type
+    type_matched = (
+        exc_type_re is None or exc_type_re.match(exception.exception_type) is not None
+    )
+    if not type_matched and exc_type_re and "." in exc_type:
+        exc_type = exc_type.rsplit(".", 1)[-1]
+        type_matched = exc_type_re.match(exc_type) is not None
+
     return (
         (
             exception_filter.message_pattern is None
             or exception_filter.message_pattern.match(exception.message) is not None
         )
-        and issubclass(exception.exception_type, exception_filter.exception_type)
+        and type_matched
         and (
             exception_filter.module_pattern is None
             or exception_filter.module_pattern.match(exception.module) is not None
@@ -91,32 +110,27 @@ def does_error_match(
     )
 
 
-def resolve_exception(exception: str) -> Type[BaseException]:
-    if "." not in exception:
-        return extra_inspect.import_name(f"builtins.{exception}")
-    return extra_inspect.import_name(exception)
-
-
 def get_exception_details(
-    exc_value: BaseException, exc_traceback: TracebackType
+    exc_type: Type[BaseException],
+    exc_value: BaseException,
+    exc_traceback: TracebackType,
 ) -> ExceptionDetails:
-    exc_type = exc_value.__class__
-    if issubclass(exc_type, RemoteException):
-        exc: RemoteException = cast(RemoteException, exc_value)
+    exc_type_name = f"{exc_type.__module__}.{exc_type.__name__}"
+    if isinstance(exc_value, RemoteException):
         import_path = ".".join(
             [
-                exc.remote_traceback.exc_module,
-                exc.remote_traceback.exc_type,
+                exc_value.remote_traceback.exc_module,
+                exc_value.remote_traceback.exc_type,
             ]
         )
-        exc_type = resolve_exception(import_path)
-        traceback = exc.remote_traceback
+        exc_type_name = import_path
+        traceback = exc_value.remote_traceback
     else:
         traceback = TracebackData.from_exc_info(exc_type, exc_value, exc_traceback)
 
     return ExceptionDetails(
         message=str(exc_value),
-        exception_type=exc_type,
+        exception_type=exc_type_name,
         module=traceback.stack[-1].module,
         lineno=traceback.stack[-1].lineno,
         traceback=traceback,
@@ -167,6 +181,8 @@ def parse_warning_filter(arg: str, *, escape: bool) -> ExceptionFilter:
         message = re.escape(message)
     if module and escape:
         module = re.escape(module) + r"\Z"
+    if category and escape:
+        category = re.escape(category) + r"\Z"
     if lineno_:
         try:
             lineno = int(lineno_)
@@ -179,8 +195,8 @@ def parse_warning_filter(arg: str, *, escape: bool) -> ExceptionFilter:
     else:
         lineno = 0
     return ExceptionFilter(
-        message_pattern=None if message == "" else re.compile(message),
-        exception_type=resolve_exception(category),
-        module_pattern=None if module == "" else re.compile(module),
+        message_pattern=re.compile(message) if message else None,
+        exception_type=re.compile(category) if category else None,
+        module_pattern=re.compile(module) if module else None,
         lineno=lineno,
     )

--- a/src/saturn_engine/worker/executors/queue.py
+++ b/src/saturn_engine/worker/executors/queue.py
@@ -69,14 +69,16 @@ class ExecutorQueue:
                         try:
                             return await self.executor.process_message(xmsg)
                         except Exception:
-                            _, exc_value, exc_traceback = sys.exc_info()
-                            # Shouldn't be None but we want to make mypy happy
-                            if exc_value is None or exc_traceback is None:
-                                raise
+                            exc_type, exc_value, exc_traceback = sys.exc_info()
+                            assert (  # noqa: S101
+                                exc_type and exc_value and exc_traceback
+                            )
                             result = process_pipeline_exception(
-                                xmsg.queue.definition.output,
-                                exc_value,
-                                exc_traceback,
+                                queue=xmsg.queue.definition,
+                                message=xmsg.message.message,
+                                exc_type=exc_type,
+                                exc_value=exc_value,
+                                exc_traceback=exc_traceback,
                             )
                             if not result:
                                 raise

--- a/src/saturn_engine/worker/services/extras/sentry.py
+++ b/src/saturn_engine/worker/services/extras/sentry.py
@@ -1,5 +1,6 @@
 import typing as t
 
+import contextlib
 import logging
 import os
 from collections.abc import AsyncGenerator
@@ -16,6 +17,7 @@ from saturn_engine.core.api import QueueItem
 from saturn_engine.utils.options import asdict
 from saturn_engine.utils.traceback_data import FrameData
 from saturn_engine.utils.traceback_data import TracebackData
+from saturn_engine.worker.error_handling import HandledError
 from saturn_engine.worker.executors.bootstrap import RemoteException
 from saturn_engine.worker.executors.executable import ExecutableMessage
 from saturn_engine.worker.executors.executable import ExecutableQueue
@@ -131,7 +133,8 @@ class Sentry(Service[BaseServices, "Sentry.Options"]):
 
             scope.add_event_processor(_event_processor)
             try:
-                yield
+                with contextlib.suppress(HandledError):
+                    yield
             except Exception as e:
                 self._capture_exception(e)
 

--- a/src/saturn_engine/worker/services/loggers/logger.py
+++ b/src/saturn_engine/worker/services/loggers/logger.py
@@ -254,10 +254,7 @@ class PipelineLogger:
     @contextlib.contextmanager
     def log_context(self, data: dict) -> Iterator[None]:
         if self.set_context:
-            tokens = self.structlog.contextvars.bind_contextvars(**data)
-            try:
+            with self.structlog.contextvars.bound_contextvars(**data):
                 yield
-            finally:
-                self.structlog.contextvars.reset_contextvars(**tokens)
         else:
             yield

--- a/src/saturn_engine/worker/services/loggers/logger.py
+++ b/src/saturn_engine/worker/services/loggers/logger.py
@@ -12,6 +12,7 @@ from saturn_engine.core import PipelineResults
 from saturn_engine.core import ResourceUsed
 from saturn_engine.core import TopicMessage
 from saturn_engine.core.api import QueueItem
+from saturn_engine.worker.error_handling import HandledError
 from saturn_engine.worker.executors.bootstrap import PipelineBootstrap
 from saturn_engine.worker.executors.executable import ExecutableMessage
 from saturn_engine.worker.executors.executable import ExecutableQueue
@@ -139,6 +140,19 @@ class Logger(Service[BaseServices, "Logger.Options"]):
                 extra={
                     "data": {
                         "result": self.result_data(result),
+                    }
+                    | trace_info
+                    | executable_message_data(xmsg, verbose=self.verbose)
+                },
+            )
+        except HandledError as e:
+            self.message_logger.warning(
+                "Failed to execute message, error handled: %s: %s",
+                e.__cause__.__class__.__name__,
+                str(e.__cause__),
+                extra={
+                    "data": {
+                        "result": self.result_data(e.results),
                     }
                     | trace_info
                     | executable_message_data(xmsg, verbose=self.verbose)

--- a/src/saturn_engine/worker/topic.py
+++ b/src/saturn_engine/worker/topic.py
@@ -19,7 +19,7 @@ class TopicClosedError(Exception):
 
 
 class Topic(OptionsSchema):
-    name: str
+    name: str = "unnamed-topic"
 
     async def run(self) -> AsyncGenerator[TopicOutput, None]:
         raise NotImplementedError()

--- a/src/saturn_engine/worker/topics/memory.py
+++ b/src/saturn_engine/worker/topics/memory.py
@@ -21,6 +21,8 @@ class MemoryOptions:
 
 
 class MemoryTopic(Topic):
+    name = "memory_topic"
+
     Options = MemoryOptions
 
     def __init__(self, options: MemoryOptions, **kwargs: Any):

--- a/src/saturn_engine/worker/work_factory.py
+++ b/src/saturn_engine/worker/work_factory.py
@@ -26,7 +26,8 @@ def build(queue_item: QueueItemWithState, *, services: Services) -> ExecutableQu
         k: [
             output
             for t in ts
-            if isinstance(output := build_item(t, services=services), Topic)
+            if isinstance(t, ComponentDefinition)
+            and isinstance(output := build_item(t, services=services), Topic)
         ]
         for k, ts in queue_item.output.items()
     }

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -255,6 +255,11 @@ def register_hooks_handler(services: Services) -> AsyncMock:
     return _hooks_handler
 
 
+class EqualAny:
+    def __eq__(self, other: t.Any) -> bool:
+        return True
+
+
 class EqualAnyOrder:
     def __init__(self, expected: t.Iterable):
         self.expected = expected

--- a/tests/worker/conftest.py
+++ b/tests/worker/conftest.py
@@ -25,6 +25,7 @@ from saturn_engine.core import Resource
 from saturn_engine.core import TopicMessage
 from saturn_engine.core.api import ComponentDefinition
 from saturn_engine.core.api import LockResponse
+from saturn_engine.core.api import OutputDefinition
 from saturn_engine.core.api import QueueItemWithState
 from saturn_engine.worker.broker import Broker
 from saturn_engine.worker.broker import WorkManagerInit
@@ -238,7 +239,7 @@ def fake_executable_maker_with_output(
         message: t.Optional[TopicMessage] = None,
         parker: t.Optional[Parkers] = None,
         pipeline_info: PipelineInfo = fake_pipeline_info,
-        output: t.Optional[dict[str, list[ComponentDefinition]]] = None,
+        output: t.Optional[dict[str, list[OutputDefinition]]] = None,
     ) -> ExecutableMessage:
         queue_item = QueueItemWithState(
             name=JobId("fake-failing-queue"),
@@ -259,6 +260,7 @@ def fake_executable_maker_with_output(
             output_topics[channel] = [
                 MemoryTopic(MemoryTopic.Options(name=topic_item.name))
                 for topic_item in topic_items
+                if isinstance(topic_item, ComponentDefinition)
             ]
 
         executable_queue = ExecutableQueue(

--- a/tests/worker/test_executor.py
+++ b/tests/worker/test_executor.py
@@ -225,15 +225,12 @@ async def test_executor_error_handler(
             )
         ]
     }
+    xmsg = fake_executable_maker_with_output(
+        output=output_topics,
+    )
     # Execute our failing message
     async with event_loop.until_idle():
-        asyncio.create_task(
-            executor_manager.submit(
-                fake_executable_maker_with_output(
-                    output=output_topics,
-                )
-            )
-        )
+        asyncio.create_task(executor_manager.submit(xmsg))
 
     # Our pipeline should cause a test exception and publish it in its channel
     assert output_queue.qsize() == 1
@@ -244,12 +241,13 @@ async def test_executor_error_handler(
     expected_message = TopicMessage(
         id=output.id,
         args={
+            "cause": xmsg.message.message,
             "error": ErrorMessageArgs(
-                type="Exception",
+                type="builtins.Exception",
                 module="tests.worker.test_executor",
                 message="TEST_EXCEPTION",
                 traceback=cast(ErrorMessageArgs, output.args["error"]).traceback,
-            )
+            ),
         },
         config={},
         metadata={},


### PR DESCRIPTION
@aviau @slaroche 

Add a few more advanced error handling, namely:

```
      error::ZeroDivisionError:
        - topic: logging-error
        - error_handler:
            set_handled: false
            republish:
              channel: default
              max_retry: 5
```

What the code above does is:

 * `topic: logging-error`: Output a message to the `logging-error` topic. This message has the `error` and `cause` attributes which is the error details and the original message causing the exception. One way to use this would be to have specific topic that can output to specific sentry or error logging system.
 * `set_handled: fase`: By default any error that match one of the `error:...` channel is set as "handled". This means that services like error logging or sentry will not handle them. Metric will increment a `error_handled` metric instead of the usual `failed` one. By using `set_handled: false`, the error will be reraise and the services will handle it as usual. Can be useful if we want to do something special with an error, but also use the default behavior.
 * `republish: ...`: Not the same as `topic: logging-error`. `republish` will publish the original message, instead of creating a new message with `{"error": ..., "cause": ...}`. Therefor it can be used to publish to a queue fed to the same pipeline so it gets retried. It also set and increment a `retried` metadata attribute to the message, so we can stop publishing the message after a threshold. If the message if not published because of max retried, the error is set as unhandled and should be logged or sent to sentry.