### PR TITLE
Add PriorityFanIn

### DIFF
--- a/tests/worker/inventories/test_fanin.py
+++ b/tests/worker/inventories/test_fanin.py
@@ -1,4 +1,5 @@
 import json
+from collections import Counter
 
 import asyncstdlib as alib
 import pytest
@@ -6,6 +7,7 @@ import pytest
 from saturn_engine.core.types import Cursor
 from saturn_engine.core.types import MessageId
 from saturn_engine.worker.inventories.fanin import FanIn
+from saturn_engine.worker.inventories.fanin import PriorityFanIn
 from saturn_engine.worker.inventory import Item
 
 
@@ -39,3 +41,41 @@ async def test_fanin_inventory() -> None:
     assert messages == [
         Item(id=MessageId("1"), cursor='{"a": "3", "b": "1"}', args={"n": 5})
     ]
+
+
+@pytest.mark.asyncio
+async def test_priority_fanin_inventory() -> None:
+    inventory = PriorityFanIn.from_options(
+        {
+            "inputs": [
+                {
+                    "priority": 1,
+                    "inventory": {
+                        "name": "a",
+                        "type": "StaticInventory",
+                        "options": {"items": [{"n": "a"}] * 100},
+                    },
+                },
+                {
+                    "priority": 2,
+                    "inventory": {
+                        "name": "b",
+                        "type": "StaticInventory",
+                        "options": {"items": [{"n": "b"}] * 100},
+                    },
+                },
+            ],
+        },
+        services=None,
+    )
+    messages = (await alib.list(inventory.iterate()))[:75]
+    counter = Counter([m.args["n"] for m in messages])
+    assert counter["a"] in range(49, 51)
+    assert counter["b"] in range(24, 26)
+
+    messages = (
+        await alib.list(inventory.iterate(after=Cursor('{"a": "70", "b": "30"}')))
+    )[:50]
+    counter = Counter([m.args["n"] for m in messages])
+    assert counter["a"] == 29
+    assert counter["b"] == 21


### PR DESCRIPTION
Similar to `FanIn` inventory, but allow settings priority to items. This is useful for the pattern where there's an inventory mixed with a recursive paging topic. The paging topic can be set with a priority `0` so it always get processed first. This should ensure it never reach a state of recursive back-pressure if the pipeline never page more than one page at a time.

There might be some rare condition where it could happen, but this is the simplest defense I could build right now.

@infherny @aviau 