### PR TITLE
Set context vars that have greater coverage and not logger specific

### DIFF
--- a/src/saturn_engine/utils/__init__.py
+++ b/src/saturn_engine/utils/__init__.py
@@ -6,6 +6,7 @@ import enum
 import threading
 from collections.abc import Iterable
 from collections.abc import Iterator
+from collections.abc import Mapping
 from datetime import datetime
 from datetime import timezone
 from functools import wraps
@@ -205,3 +206,14 @@ if not (ExceptionGroup := getattr(builtins, "ExceptionGroup", None)):  # type: i
         def __init__(self, msg: str, errors: list[Exception]) -> None:
             super().__init__(msg)
             self.errors = errors
+
+
+def deep_merge(*dicts: Mapping) -> dict:
+    merged: dict = {}
+    for d in dicts:
+        for k, v in d.items():
+            mv = merged.get(k, ...)
+            if mv is not ... and isinstance(v, Mapping) and isinstance(mv, Mapping):
+                v = deep_merge(mv, v)
+            merged[k] = v
+    return merged

--- a/src/saturn_engine/utils/iterators.py
+++ b/src/saturn_engine/utils/iterators.py
@@ -66,6 +66,18 @@ async def async_enter(
         yield (context, item)
 
 
+async def contextualize(
+    iterator: t.AsyncIterator[T], *, context: t.Callable[[], t.AsyncContextManager]
+) -> t.AsyncIterator[T]:
+    while True:
+        async with context():
+            try:
+                item = await iterator.__anext__()
+            except StopAsyncIteration:
+                break
+        yield item
+
+
 @contextlib.asynccontextmanager
 async def scoped_aiters(
     *iterators: t.AsyncIterator[T],

--- a/src/saturn_engine/worker/context.py
+++ b/src/saturn_engine/worker/context.py
@@ -1,0 +1,65 @@
+import typing as t
+
+import contextlib
+from contextvars import ContextVar
+
+from saturn_engine.core.api import QueueItem
+from saturn_engine.core.pipeline import PipelineInfo
+from saturn_engine.core.topic import TopicMessage
+
+
+class ContextVars:
+    job: t.Final[ContextVar[t.Optional[QueueItem]]] = ContextVar(
+        "saturn.job", default=None
+    )
+    pipeline: t.Final[ContextVar[t.Optional[PipelineInfo]]] = ContextVar(
+        "saturn.pipeline", default=None
+    )
+    message: t.Final[ContextVar[t.Optional[TopicMessage]]] = ContextVar(
+        "saturn.message", default=None
+    )
+
+    @classmethod
+    def context_summary(cls) -> dict[str, t.Any]:
+        summary: dict[str, t.Any] = {}
+        if job := cls.job.get():
+            summary["job"] = {"name": job.name}
+
+        if pipeline := cls.pipeline.get():
+            summary["pipeline"] = pipeline.name
+
+        if message := cls.message.get():
+            summary["message"] = {
+                "id": message.id,
+                "tags": message.tags,
+            }
+
+        return summary
+
+
+@contextlib.contextmanager
+def pipeline_context(pipeline: PipelineInfo) -> t.Iterator[None]:
+    token = ContextVars.pipeline.set(pipeline)
+    try:
+        yield
+    finally:
+        ContextVars.pipeline.reset(token)
+
+
+@contextlib.contextmanager
+def message_context(msg: TopicMessage) -> t.Iterator[None]:
+    token = ContextVars.message.set(msg)
+    try:
+        yield
+    finally:
+        ContextVars.message.reset(token)
+
+
+@contextlib.contextmanager
+def job_context(job: QueueItem) -> t.Iterator[None]:
+    token = ContextVars.job.set(job)
+    try:
+        with pipeline_context(job.pipeline.info):
+            yield
+    finally:
+        ContextVars.job.reset(token)

--- a/src/saturn_engine/worker/executors/bootstrap.py
+++ b/src/saturn_engine/worker/executors/bootstrap.py
@@ -13,6 +13,8 @@ from saturn_engine.core.pipeline import PipelineResultTypes
 from saturn_engine.utils.hooks import ContextHook
 from saturn_engine.utils.hooks import EventHook
 from saturn_engine.utils.traceback_data import TracebackData
+from saturn_engine.worker.context import message_context
+from saturn_engine.worker.context import pipeline_context
 from saturn_engine.worker.pipeline_message import PipelineMessage
 
 PipelineHook = ContextHook[PipelineMessage, PipelineResults]
@@ -29,7 +31,8 @@ class PipelineBootstrap:
 
     def bootstrap_pipeline(self, message: PipelineMessage) -> PipelineResults:
         message.set_meta_arg(meta_type=TopicMessage, value=message.message)
-        return self.pipeline_hook.emit(self.run_pipeline)(message)
+        with pipeline_context(message.info), message_context(message.message):
+            return self.pipeline_hook.emit(self.run_pipeline)(message)
 
     def run_pipeline(self, message: PipelineMessage) -> PipelineResults:
         execute_result = message.execute()

--- a/src/saturn_engine/worker/executors/manager.py
+++ b/src/saturn_engine/worker/executors/manager.py
@@ -107,8 +107,9 @@ class ExecutorWorker:
 
         # Go through all queue in the Ready state.
         async for message in self.scheduler.run():
-            await self.services.s.hooks.message_scheduled.emit(message)
-            await self.executor_queue.submit(message)
+            with message.saturn_context():
+                await self.services.s.hooks.message_scheduled.emit(message)
+                await self.executor_queue.submit(message)
         self.logger.debug("Executor worker done")
 
     async def close(self) -> None:

--- a/src/saturn_engine/worker/services/loggers/console_logging.py
+++ b/src/saturn_engine/worker/services/loggers/console_logging.py
@@ -3,7 +3,9 @@ import typing as t
 import logging
 import logging.config
 
+from saturn_engine.utils import deep_merge
 from saturn_engine.utils.serializer import human_encode
+from saturn_engine.worker import context
 
 from .. import MinimalService
 
@@ -19,6 +21,11 @@ class ConsoleLogging(MinimalService):
 def setup(*args: t.Any) -> None:
     if not setup_structlog():
         setup_logging()
+
+
+def merge_contextvars(logger: t.Any, method_name: str, event_dict: dict) -> dict:
+    summary = context.ContextVars.context_summary()
+    return deep_merge(summary, event_dict) if summary else event_dict
 
 
 def setup_structlog() -> bool:
@@ -42,6 +49,7 @@ def setup_structlog() -> bool:
 
     pre_chain = [
         structlog.contextvars.merge_contextvars,
+        merge_contextvars,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.add_log_level,
         unwrap_extra_data,

--- a/src/saturn_engine/worker/services/loggers/logger.py
+++ b/src/saturn_engine/worker/services/loggers/logger.py
@@ -30,7 +30,7 @@ def executable_message_data(
 ) -> dict[str, t.Any]:
     labels = xmsg.queue.definition.labels.copy()
     return pipeline_message_data(xmsg.message, verbose=verbose) | {
-        "job": xmsg.queue.name,
+        "job": {"name": xmsg.queue.name},
         "input": xmsg.queue.definition.input.name,
         "labels": labels,
     }

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import pytest
 
+from saturn_engine.utils import deep_merge
 from saturn_engine.utils import get_own_attr
 from saturn_engine.utils import has_own_attr
 from saturn_engine.utils import lazy
@@ -74,3 +75,20 @@ def test_lazy() -> None:
     compute.clear()
     assert compute() == "aa"
     assert count == 2
+
+
+def test_deep_merge() -> None:
+    assert deep_merge(
+        {
+            "a": 1,
+            "b": 0,
+            "c": {"x": 1, "z": 3},
+        },
+        {
+            "b": {"x": 1},
+            "c": {"y": 2, "z": 0},
+        },
+        {
+            "d": "foo",
+        },
+    ) == {"a": 1, "b": {"x": 1}, "c": {"x": 1, "y": 2, "z": 0}, "d": "foo"}

--- a/tests/worker/services/test_logger.py
+++ b/tests/worker/services/test_logger.py
@@ -63,7 +63,7 @@ async def test_logger_message_executed(
         assert r.message == "Executing message"
         assert r.data == {
             "input": "fake-topic",
-            "job": "fake-queue",
+            "job": {"name": "fake-queue"},
             "message": {
                 "id": "m1",
                 "tags": {},
@@ -83,7 +83,9 @@ async def test_logger_message_executed(
         assert r.message == "Executed message"
         assert r.data == {
             "input": "fake-topic",
-            "job": "fake-queue",
+            "job": {
+                "name": "fake-queue",
+            },
             "message": {
                 "id": "m1",
                 "tags": {},


### PR DESCRIPTION
Right now context is attached to log if they fall without the `Logger` hooks, but anything else lack context.

This PR add a new `context` module that allow any code to set the current task context that can then be reused by any other component (metrics, logger, etc.). Most log should not be tagged with their proper job or message!