### PR TITLE
Fix racy inspect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ trace.db
 *.egg-info
 /.python-version
 /docs/_build
+/example/definitions/tests.yaml

--- a/example/definitions/executor.yaml
+++ b/example/definitions/executor.yaml
@@ -25,4 +25,4 @@ spec:
   type: ARQExecutor
   options:
     redis_url: "redis://localhost"
-    concurrency: 4
+    concurrency: 2

--- a/example/src/example/pipelines.py
+++ b/example/src/example/pipelines.py
@@ -74,6 +74,11 @@ def fast(**kwargs: t.Any) -> TopicMessage:
     return TopicMessage(args=kwargs)
 
 
+def sleep(delay: float = 10, **kwargs: t.Any) -> None:
+    logging.info(kwargs)
+    time.sleep(delay)
+
+
 def paginate(p: int = 0, **kwargs: t.Any) -> t.Optional[PipelineOutput]:
     trace_pipeline("paginate", kwargs)
     time.sleep(0.1)


### PR DESCRIPTION
Don't mind the example files, look at the `inspect.py`

I think I found why the cause of these import error when worker starts.

Seems like our race condition fix didn't work. Looking at CPython, `sys.modules` can contains partial module. At that point is also seem that `import_module` does check if the module is already completely imported before trying to import, so we might as well just use it instead of our half-baked `if mod not in sys.module: ... else return sys.module[mod]`