### PR TITLE
arq: Add healthcheck to detect when worker die

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ trace.db
 *.egg-info
 /.python-version
 /docs/_build
+/example/definitions/tests.yaml

--- a/example/definitions/executor.yaml
+++ b/example/definitions/executor.yaml
@@ -25,4 +25,4 @@ spec:
   type: ARQExecutor
   options:
     redis_url: "redis://localhost"
-    concurrency: 4
+    concurrency: 2

--- a/example/src/example/pipelines.py
+++ b/example/src/example/pipelines.py
@@ -74,6 +74,11 @@ def fast(**kwargs: t.Any) -> TopicMessage:
     return TopicMessage(args=kwargs)
 
 
+def sleep(delay: float = 10, **kwargs: t.Any) -> None:
+    logging.info(kwargs)
+    time.sleep(delay)
+
+
 def paginate(p: int = 0, **kwargs: t.Any) -> t.Optional[PipelineOutput]:
     trace_pipeline("paginate", kwargs)
     time.sleep(0.1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,5 +134,6 @@ plugins = ["sqlalchemy.ext.mypy.plugin", "mypy_typing_asserts.mypy_plugin"]
 module = [
   "nox.*",
   "nox_poetry.*",
+  "aioredis.*",
 ]
 ignore_missing_imports = true

--- a/src/saturn_engine/worker/executors/arq/__init__.py
+++ b/src/saturn_engine/worker/executors/arq/__init__.py
@@ -1,3 +1,9 @@
 QUEUE_TIMEOUT = 600
 RESULT_TIMEOUT = 1200
 EXECUTE_FUNC_NAME = "remote_execute"
+
+healthcheck_interval = 10
+
+
+def healthcheck_key(job_id: str) -> str:
+    return f"saturn:arq:{job_id}:healthcheck"


### PR DESCRIPTION
Looking at our logs, found out that an ARQ worker dying means Saturn is going to wait for the timeout to trigger. I added a small healthcheck system for each message so we can detect when a worker processing a message went down instead of waiting for the much longer timeout. (10s vs 10m in some cases)