### PR TITLE
Allow custom executor

### DIFF
--- a/src/saturn_engine/utils/lru.py
+++ b/src/saturn_engine/utils/lru.py
@@ -16,7 +16,8 @@ class LRUDefaultDict(OrderedDict[K, V]):
         *args: list[t.Any],
         **kwargs: dict[str, t.Any]
     ):
-        assert cache_len > 0
+        if cache_len <= 0:
+            raise ValueError("cache_len must be greater than 0")
         self.cache_len = cache_len
         self.default_factory = default_factory
 

--- a/src/saturn_engine/worker/executors/arq/worker.py
+++ b/src/saturn_engine/worker/executors/arq/worker.py
@@ -1,6 +1,8 @@
 import typing as t
 
 import asyncio
+import enum
+import multiprocessing
 from concurrent import futures
 
 import arq.worker
@@ -20,29 +22,63 @@ from . import healthcheck_interval
 from . import healthcheck_key
 
 
+class WorkerType(enum.Enum):
+    PROCESS = "process"
+    THREAD = "thread"
+
+
 class WorkerOptions(t.TypedDict, total=False):
     worker_concurrency: int
     worker_initializer: t.Optional[t.Callable[[PipelineBootstrap], t.Any]]
+    worker_type: WorkerType
 
 
 class Context(WorkerOptions):
     executor: futures.Executor
-    bootstraper: PipelineBootstrap
     redis: ArqRedis
     job_id: str
 
 
+_bootstraper: t.Optional[PipelineBootstrap] = None
+
+
+def _init_bootstraper(
+    worker_initializer: t.Optional[t.Callable[[PipelineBootstrap], t.Any]]
+) -> None:
+    global _bootstraper
+
+    initialize_hook: EventHook[PipelineBootstrap] = EventHook()
+
+    # Arq doesn't support passing hook, so we hard code service hooks here.
+    # Would be nice to find a way around that eventually.
+    initialize_hook.register(logger.on_executor_initialized)
+    initialize_hook.register(tracing.on_executor_initialized)
+
+    if worker_initializer:
+        initialize_hook.register(worker_initializer)
+
+    _bootstraper = PipelineBootstrap(initialized_hook=initialize_hook)
+
+
+def _ensure_bootstraper() -> PipelineBootstrap:
+    if _bootstraper is None:
+        raise ValueError("Bootstraper wasn't initialized")
+    return _bootstraper
+
+
+def remote_bootstrap(message: PipelineMessage) -> PipelineResults:
+    bootstraper = _ensure_bootstraper()
+    return bootstraper.bootstrap_pipeline(message)
+
+
 async def remote_execute(ctx: Context, message: PipelineMessage) -> PipelineResults:
     executor = ctx["executor"]
-    bootstraper = ctx["bootstraper"]
     with wrap_remote_exception():
         loop = asyncio.get_running_loop()
         tasks = TasksGroup(name=f"saturn.arq.remote({message.id})")
 
         async def execute_message() -> PipelineResults:
-            return await loop.run_in_executor(
-                executor, bootstraper.bootstrap_pipeline, message
-            )
+            return await loop.run_in_executor(executor, remote_bootstrap, message)
 
         executor_task = tasks.create_task(execute_message())
         tasks.create_task(remote_job_healthcheck(ctx))
@@ -65,23 +101,34 @@ async def remote_job_healthcheck(ctx: Context) -> None:
         await asyncio.sleep(healthcheck_interval)
 
 
+def remote_initializer(
+    worker_initializer: t.Optional[t.Callable[[PipelineBootstrap], t.Any]]
+) -> None:
+    _init_bootstraper(worker_initializer)
+
+
 async def startup(ctx: Context) -> None:
     worker_concurrency = ctx.get("worker_concurrency", 4)
     worker_initializer = ctx.get("worker_initializer", None)
+    worker_type = ctx.get("worker_type", WorkerType.THREAD)
 
-    executor = futures.ThreadPoolExecutor(max_workers=worker_concurrency)
+    if "executor" not in ctx:
+        if worker_type is WorkerType.PROCESS:
+            context = multiprocessing.get_context("spawn")
+            executor = futures.ProcessPoolExecutor(
+                max_workers=worker_concurrency,
+                initializer=remote_initializer,
+                initargs=(worker_initializer,),
+                mp_context=context,
+            )
+        else:
+            executor = futures.ThreadPoolExecutor(
+                max_workers=worker_concurrency, thread_name_prefix="saturn-arq-"
+            )
 
-    ctx["executor"] = executor
-    initialize_hook: EventHook[PipelineBootstrap] = EventHook()
-    if worker_initializer:
-        initialize_hook.register(worker_initializer)
+        ctx["executor"] = executor
 
-    # Arq doesn't support passing hook, so we hard code service hooks here.
-    # Would be nice to find a way around that eventually.
-    initialize_hook.register(logger.on_executor_initialized)
-    initialize_hook.register(tracing.on_executor_initialized)
-
-    ctx["bootstraper"] = PipelineBootstrap(initialized_hook=initialize_hook)
+    _init_bootstraper(worker_initializer)
 
 
 async def shutdown(ctx: Context) -> None:


### PR DESCRIPTION
@infherny 

This way a custom worker could pass its own executor such as a multi process pool.