### PR TITLE
 Merged queue timeout and result timeout 

### DIFF
--- a/src/saturn_engine/worker/executors/arq/__init__.py
+++ b/src/saturn_engine/worker/executors/arq/__init__.py
@@ -1,5 +1,4 @@
-QUEUE_TIMEOUT = 600
-RESULT_TIMEOUT = 1200
+TIMEOUT = 1200
 EXECUTE_FUNC_NAME = "remote_execute"
 
 healthcheck_interval = 10


### PR DESCRIPTION
With recent ARQ changes, it is now possible to raise `TimeoutError` from diverging values of queues and results timeouts. This aims to give us saner defaults