### PR TITLE
chore: reduce the number of layers in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@
 ###########
 FROM python:3.10-slim-bullseye as build
 
+ENV POETRY_VERSION=1.1.11
+
 RUN apt-get update \
     && apt-get install -y git build-essential \
-    && rm -rf /var/lib/apt/lists/*
-
-ENV POETRY_VERSION=1.1.11
-RUN pip install poetry==${POETRY_VERSION}
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install poetry==${POETRY_VERSION}
 
 WORKDIR /opt/saturn
 
@@ -22,13 +22,12 @@ RUN poetry build
 ################
 FROM python:3.10-slim-bullseye
 
-RUN apt-get update \
-    && apt-get install -y git build-essential \
-    && rm -rf /var/lib/apt/lists/*
-
 COPY --from=build /opt/saturn/dist/*.whl /opt/saturn/
 
-RUN pip install /opt/saturn/*.whl \
+RUN apt-get update \
+    && apt-get install -y git build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install /opt/saturn/*.whl \
     && rm -rf /opt/saturn
 
 ENV SATURN_FLASK_HOST=0.0.0.0


### PR DESCRIPTION
# Purpose

Reduce the number of layer in a docker image will result in a smaller docker image filesize

# Why ?

When doing RUN commands, each of them will create a new layer on the docker file system which will

- Increase the image size (Hence more storage cost for images and disk space used)
- Make the build a little slower

# Note

I didn't combine the poetry build statement as we want still to have incremental rebuild when doing new builds, the ADD statement caches the file and won't run the sub-sequent RUN command if nothing has changed