### PR TITLE
chore: simplify the join definition logic, add exception test

### DIFF
--- a/src/saturn_engine/models/queue.py
+++ b/src/saturn_engine/models/queue.py
@@ -47,19 +47,19 @@ class Queue(Base):
 
     def join_definitions(self, static_definitions: StaticDefinitions) -> None:
         if not self.job:
-            self._queue_item = dataclasses.replace(
-                static_definitions.jobs[self.job.name],
-                name=JobId(self.name),
-            ).with_state(state)
-            return
-
-        if self.job.job_definition_name is None:
             raise NotImplementedError("Only support Job queue")
 
         state = QueueItemState(
             cursor=Cursor(self.job.cursor) if self.job.cursor else None,
             started_at=self.job.started_at,
         )
+
+        if self.job.job_definition_name is None:
+            self._queue_item = dataclasses.replace(
+                static_definitions.jobs[self.job.name],
+                name=JobId(self.name),
+            ).with_state(state)
+            return
 
         self._queue_item = dataclasses.replace(
             static_definitions.job_definitions[

--- a/src/saturn_engine/models/queue.py
+++ b/src/saturn_engine/models/queue.py
@@ -62,8 +62,6 @@ class Queue(Base):
             return
 
         self._queue_item = dataclasses.replace(
-            static_definitions.job_definitions[
-                self.job.job_definition_name
-            ].template,
+            static_definitions.job_definitions[self.job.job_definition_name].template,
             name=JobId(self.name),
         ).with_state(state)

--- a/tests/models/test_queue.py
+++ b/tests/models/test_queue.py
@@ -1,0 +1,37 @@
+import pytest
+
+from saturn_engine.models import Queue
+from saturn_engine.worker_manager.config.declarative import load_definitions_from_str
+
+static_job_definition: str = """
+---
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnJobDefinition
+metadata:
+  name: test-job-definition
+  labels:
+    owner: team-saturn
+spec:
+  minimalInterval: "@weekly"
+  template:
+    input:
+      inventory: test-inventory
+
+    pipeline:
+      name: something.saturn.pipelines.aa.bb
+---
+apiVersion: saturn.flared.io/v1alpha1
+kind: SaturnInventory
+metadata:
+  name: test-inventory
+spec:
+  type: testtype
+---
+
+"""
+
+
+def test_join_definitions_should_raise_exception_on_undefined_job_object() -> None:
+    with pytest.raises(NotImplementedError):
+        static_definitions = load_definitions_from_str(static_job_definition)
+        Queue(name="test").join_definitions(static_definitions)


### PR DESCRIPTION
# Purpose

Added a unit test to make sure we raised the good exception on the missing job queue

We already test the state update thrugh integration test but we never made sure that the exception is raised for the missing job queue (the failing test)

# Things I made sure so we're back to green

[X] Lint passing : yes
[X] Did you run the tests ? : yes


cc @isra17 

Small note it could also be nice to add a PULL_REQUEST_TEMPLATE for projects like this especially if you don't run the tests on every push so people don't forget to run them

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository