### PR TITLE
[Metrics] Add original job definition name to pipeline metrics tags

### DIFF
--- a/src/saturn_engine/worker_manager/config/declarative_job.py
+++ b/src/saturn_engine/worker_manager/config/declarative_job.py
@@ -98,7 +98,7 @@ class JobSpec:
                 ),
                 labels=dict(
                     {
-                        "job-definition-name": name,
+                        "internal.job-definition-name": name,
                     },
                     **labels,
                 ),

--- a/src/saturn_engine/worker_manager/config/declarative_job.py
+++ b/src/saturn_engine/worker_manager/config/declarative_job.py
@@ -96,7 +96,12 @@ class JobSpec:
                     info=self.pipeline.to_core_object(),
                     args=dict(),
                 ),
-                labels=labels,
+                labels=dict(
+                    {
+                        "job-definition-name": name,
+                    },
+                    **labels,
+                ),
                 config=self.config,
                 executor=self.executor,
             )

--- a/tests/worker/services/test_usage_metrics.py
+++ b/tests/worker/services/test_usage_metrics.py
@@ -26,10 +26,15 @@ async def test_message_metrics(
         xmsg: ExecutableMessage = Mock()
         xmsg.message.info.name = pipeline_name
         xmsg.queue.definition.executor = "default"
+        xmsg.queue.definition.labels = {"k": "v"}
         xmsgs.append(xmsg)
 
     any_: t.Any = None
-    pipeline_params = {"pipeline": pipeline_name, "executor": "default"}
+    pipeline_params = {
+        "pipeline": pipeline_name,
+        "executor": "default",
+        "saturn.job.labels.k": "v",
+    }
     results = PipelineResults(outputs=[], resources=[])
     metric = services_manager.services.cast_service(UsageMetrics)
 

--- a/tests/worker_manager/api/test_job_definitions.py
+++ b/tests/worker_manager/api/test_job_definitions.py
@@ -93,7 +93,7 @@ spec:
                     },
                     "labels": {
                         "owner": "team-saturn",
-                        "job-definition-name": "test-job-definition",
+                        "internal.job-definition-name": "test-job-definition",
                     },
                     "config": {
                         "tracer": {

--- a/tests/worker_manager/api/test_job_definitions.py
+++ b/tests/worker_manager/api/test_job_definitions.py
@@ -91,7 +91,10 @@ spec:
                             "resources": {"api_key": "GithubApiKey"},
                         },
                     },
-                    "labels": {"owner": "team-saturn"},
+                    "labels": {
+                        "owner": "team-saturn",
+                        "job-definition-name": "test-job-definition",
+                    },
                     "config": {
                         "tracer": {
                             "sampler": {


### PR DESCRIPTION
When tracking pipeline metrics, we currently can only filter down by pipeline name, executor name and job id. There is currently no way of filtering them by job name.

I would even argue that we should maybe remove the jobId from the tags, because it has a very high cardinality.

I'm not sure i'm happy with adding this field right on the QueueItem. I wonder if we should have some sort of `tags` dictionary instead containing both the executor name and the job definition name?

Another avenue would be to leverage the job labels, but i feel like this might be mixing up some concepts.